### PR TITLE
Fix SQS delete providing proper URL

### DIFF
--- a/awssqs/.gitignore
+++ b/awssqs/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 bin/
 creds
+.env

--- a/awssqs/main.go
+++ b/awssqs/main.go
@@ -112,7 +112,7 @@ func (sqsMsg) ReceiveMsg(sqsClient *sqs.SQS, sink string) {
 			}
 
 			//Delete message from queue if we pushed successfully
-			err = deleteMessage(sqsClient, msg)
+			err = deleteMessage(sqsClient, queueURL, msg)
 			if err != nil {
 				log.Error(err)
 				continue
@@ -122,9 +122,9 @@ func (sqsMsg) ReceiveMsg(sqsClient *sqs.SQS, sink string) {
 }
 
 //Deletes message from sqs queue
-func deleteMessage(sqsClient *sqs.SQS, msg *sqs.ReceiveMessageOutput) error {
+func deleteMessage(sqsClient *sqs.SQS, queueURL string, msg *sqs.ReceiveMessageOutput) error {
 	deleteParams := &sqs.DeleteMessageInput{
-		QueueUrl:      aws.String(queueEnv),
+		QueueUrl:      aws.String(queueURL),
 		ReceiptHandle: msg.Messages[0].ReceiptHandle,
 	}
 	_, err := sqsClient.DeleteMessage(deleteParams)


### PR DESCRIPTION
@sebgoa I tested S3 and found a small bug that I think I needed to fix. The message in the queue could not be properly deleted because the provided URL was not correct. Now works fine, please have a look