### PR TITLE
ci: improved build scripts and release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,92 +1,137 @@
-version: 2
+version: 2.1
+
+orbs:
+  go: circleci/go@1.1.1
+  gcp-cli: circleci/gcp-cli@1.8.4
 
 jobs:
-  checkout-code:
-    docker:
-      - image: cimg/go:1.14
-    working_directory: /home/circleci/go/src/github.com/triggermesh/aws-event-sources
+  build:
+    executor:
+      name: go/default
+      tag: '1.14'
     steps:
       - checkout
+      - restore_cache:
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
       - run:
           name: Downloading Go modules
           command: make mod-download
       - save_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
           paths:
-            - /home/circleci/go/
-
-  build:
-    docker:
-      - image: cimg/go:1.14
-    working_directory: /home/circleci/go/src/github.com/triggermesh/aws-event-sources
-    steps:
-      - restore_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+            - $GOPATH/pkg/mod
       - run:
           name: Building package
           command: make build
+      - gcp-cli/install
+      - gcp-cli/initialize
+      - run:
+          name: Building docker image
+          command: |
+            gcloud builds submit --config cloudbuild.yaml --substitutions _KANIKO_NO_PUSH=true
 
   test:
-    docker:
-      - image: cimg/go:1.14
-    working_directory: /home/circleci/go/src/github.com/triggermesh/aws-event-sources
+    executor:
+      name: go/default
+      tag: '1.14'
     steps:
+      - checkout
       - restore_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
+      - run:
+          name: Downloading Go modules
+          command: make mod-download
+      - save_cache:
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
+          paths:
+            - $GOPATH/pkg/mod
       - run:
           name: Validating code formatting
           command: make fmt-test
       - run:
-          name: Vetting source code
+          name: Vetting code
           command: make vet
       - run:
-          name: Running unit tests
-          command: |
-            mkdir -p /tmp/tests
-            OUTPUT_DIR=/tmp/tests/ make test
+          name: Running go unit tests
+          command: mkdir -p ${OUTPUT_DIR} && make test
+          environment:
+            OUTPUT_DIR: /tmp/test-results/
       - store_test_results:
-          path: /tmp/tests
+          path: /tmp/test-results/
       - run:
           name: Generating coverage report
-          command: |
-            mkdir -p /tmp/artifacts
-            OUTPUT_DIR=/tmp/artifacts/ make coverage
+          command: mkdir -p ${OUTPUT_DIR} && make coverage
+          environment:
+            OUTPUT_DIR: /tmp/artifacts/
       - store_artifacts:
-          path: /tmp/artifacts
+          path: /tmp/artifacts/
 
-  publish-image:
-    docker:
-      - image: google/cloud-sdk:latest
-    working_directory: /home/circleci/go/src/github.com/triggermesh/aws-event-sources
+  publish:
+    executor:
+      name: gcp-cli/google
     steps:
+      - checkout
+      - gcp-cli/initialize
+      - run:
+          name: Publishing docker image
+          command: gcloud builds submit --config cloudbuild.yaml --substitutions _KANIKO_IMAGE_TAG=${CIRCLE_TAG:-latest}
+
+  release:
+    executor:
+      name: go/default
+      tag: '1.14'
+    steps:
+      - checkout
       - restore_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
       - run:
-          name: Configuring Google Cloud SDK
-          command: |
-            echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+          name: Downloading Go modules
+          command: make mod-download
+      - save_cache:
+          key: v1-repo-{{ .Environment.CIRCLE_BRANCH }}
+          paths:
+            - $GOPATH/pkg/mod
       - run:
-          name: Building Docker image
+          name: Building release packages
+          command: make release
+          environment:
+            DIST_DIR: /tmp/dist/
+      - run:
+          name: Installing github-release tool
+          command: go get github.com/aktau/github-release
+      - run:
+          name: Creating github release
           command: |
-            gcloud builds submit --config cloudbuild.yaml
+            PRE_RELEASE=${CIRCLE_TAG/${CIRCLE_TAG%-rc[0-9]*}/}
+            github-release delete -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} 2>/dev/null ||:
+            ./scripts/release-notes.sh ${CIRCLE_TAG} | github-release release ${PRE_RELEASE:+-p} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d -
+            for f in $(find /tmp/dist -type f); do github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f} ; done
 
 workflows:
-  version: 2
   build-test-and-publish:
     jobs:
-      - checkout-code
       - build:
-          requires:
-            - checkout-code
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - test:
-          requires:
-            - checkout-code
-      - publish-image:
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+      - publish:
           requires:
             - build
             - test
           filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
               only: master
+      - release:
+          requires:
+            - publish
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              ignore: /.*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,11 @@
-.git/
-.dockerignore
-**/.gitignore
-**/c.out
 **/*-coverage.html
 **/*-unit-tests.xml
-**/README.md
 **/*_test.go
-**/Makefile
+**/.gitignore
+**/c.out
+**/README.md
+.dockerignore
+.git/
 awscodecommit/awscodecommit
 awscognito/awscognito
 awsdynamodb/awsdynamodb

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,47 +3,59 @@ steps:
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awscodecommit/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awscodecommit:latest
-  - --cache=$_USE_BUILD_CACHE
-  - $_KANIKO_EXTRA_ARGS
+  - --destination=gcr.io/$PROJECT_ID/awscodecommit:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/awscodecommit/cache
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awscognito/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awscognito:latest
-  - --cache=$_USE_BUILD_CACHE
-  - $_KANIKO_EXTRA_ARGS
+  - --destination=gcr.io/$PROJECT_ID/awscognito:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/awscognito/cache
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awsdynamodb/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awsdynamodb:latest
-  - --cache=$_USE_BUILD_CACHE
-  - $_KANIKO_EXTRA_ARGS
+  - --destination=gcr.io/$PROJECT_ID/awsdynamodb:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/awsdynamodb/cache
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awskinesis/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awskinesis:latest
-  - --cache=$_USE_BUILD_CACHE
-  - $_KANIKO_EXTRA_ARGS
+  - --destination=gcr.io/$PROJECT_ID/awskinesis:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/awskinesis/cache
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awssqs/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awssqs:latest
-  - --cache=$_USE_BUILD_CACHE
-  - $_KANIKO_EXTRA_ARGS
+  - --destination=gcr.io/$PROJECT_ID/awssqs:${_KANIKO_IMAGE_TAG}
+  - --cache-repo=gcr.io/$PROJECT_ID/awssqs/cache
+  - --cache=${_KANIKO_USE_BUILD_CACHE}
+  - --no-push=${_KANIKO_NO_PUSH}
+  - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
 timeout: 600s
 
 substitutions:
-  _USE_BUILD_CACHE: "true"
+  _KANIKO_IMAGE_TAG: "latest"
+  _KANIKO_NO_PUSH: "false"
+  _KANIKO_USE_BUILD_CACHE: "true"
   _KANIKO_EXTRA_ARGS: ""
 
 options:

--- a/scripts/inc.Makefile
+++ b/scripts/inc.Makefile
@@ -1,55 +1,71 @@
+TARGETS    ?= darwin/amd64 linux/amd64
+
 RM         ?= rm
 CP         ?= cp
 MV         ?= mv
 MKDIR      ?= mkdir
+
+DOCKER     ?= docker
+IMAGE_REPO ?= gcr.io/triggermesh
+IMAGE      ?= $(IMAGE_REPO)/$(PACKAGE)
 
 GO         ?= go
 GOFMT      ?= gofmt
 GOLINT     ?= golint
 GOTOOL     ?= go tool
 GOTEST     ?= gotestsum --junitfile $(OUTPUT_DIR)$(PACKAGE)-unit-tests.xml --
-LDFLAGS    ?=
+LDFLAGS    +=
 
-DOCKER     ?= docker
-
-.PHONY: help mod-download build install test coverage lint vet fmt fmt-test image clean
+.PHONY: help mod-download build install release test coverage lint vet fmt fmt-test image clean
 
 all: build
 
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*?## "; printf "\n$(PACKAGE_DESC)\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9._-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-mod-download: ## Download modules using 'go mod download'
+mod-download: ## Download go modules
 	$(GO) mod download
 
-build: ## Build the binary using 'go build'
-	$(GO) build -ldflags "$(LDFLAGS)" -installsuffix cgo -o $(PACKAGE)
+build: ## Build the binary
+	$(GO) build -ldflags "$(LDFLAGS)" -o $(PACKAGE) -installsuffix cgo
 
-install: ## Install the binary using the 'go install'
+install: ## Install the binary
 	$(GO) install -ldflags "$(LDFLAGS)" -installsuffix cgo
 
+release: ## Build release binaries
+	@set -e ; \
+	for platform in $(TARGETS); do \
+		GOOS=$${platform%/*} ; \
+		GOARCH=$${platform#*/} ; \
+		RELEASE_BINARY=$(PACKAGE)-$${GOOS}-$${GOARCH} ; \
+		[ $${GOOS} = "windows" ] && RELEASE_BINARY=$${RELEASE_BINARY}.exe ; \
+		echo "GOOS=$${GOOS} GOARCH=$${GOARCH} $(GO) build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)$${RELEASE_BINARY} -installsuffix cgo" ; \
+		GOOS=$${GOOS} GOARCH=$${GOARCH} $(GO) build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)$${RELEASE_BINARY} -installsuffix cgo ; \
+	done
+
 test: ## Run unit tests
-	$(GOTEST) -coverprofile=c.out ./...
+	$(GOTEST) -cover -coverprofile=c.out ./...
 
 coverage: ## Generate code coverage
-	@$(GOTOOL) cover -html=c.out -o $(OUTPUT_DIR)$(PACKAGE)-coverage.html
+	$(GOTOOL) cover -html=c.out -o $(OUTPUT_DIR)$(PACKAGE)-coverage.html
 
-lint: ## Link source files using 'golint'
+lint: ## Link source files
 	$(GOLINT) ./...
 
-vet: ## Vet source files using 'go vet'
+vet: ## Vet source files
 	$(GO) vet ./...
 
-fmt: ## Format source files using 'gofmt'
-	$(GOFMT) -s -w $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}}{{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}}{{end}}' ./...)
+fmt: ## Format source files
+	$(GOFMT) -s -w $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}} {{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}} {{end}}' ./...)
 
-fmt-test: ## Check source formatting using 'gofmt'
-	@test -z $(shell $(GOFMT) -l $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}}{{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}}{{end}}' ./...))
+fmt-test: ## Check source formatting
+	@test -z $(shell $(GOFMT) -l $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}} {{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}} {{end}}' ./...))
 
-image: ## Build docker image using 'docker build'
-	$(DOCKER) build -t gcr.io/triggermesh/$(PACKAGE) -f Dockerfile ../
+image: ## Builds the container image
+	$(DOCKER) build -t $(IMAGE) -f Dockerfile ../
 
 clean: ## Clean build artifacts
-	@$(RM) -rf $(PACKAGE)
-	@$(RM) -rf $(PACKAGE)-unit-tests.xml
-	@$(RM) -rf c.out $(PACKAGE)-coverage.html
+	$(RM) -rf $(PACKAGE)
+	$(RM) -rf $(PACKAGE)-unit-tests.xml
+	$(RM) -rf c.out $(PACKAGE)-coverage.html
+	@for platform in $(TARGETS); do $(RM) -rf $(DIST_DIR)$(PACKAGE)-$${platform%/*}-$${platform#*/}; done

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+
+RELEASE=${GIT_TAG:-$1}
+
+if [ -z "${RELEASE}" ]; then
+	echo "Usage:"
+	echo "./scripts/release-notes.sh v0.1.0"
+	exit 1
+fi
+
+if ! git rev-list ${RELEASE} >/dev/null 2>&1; then
+	echo "${RELEASE} does not exist"
+	exit
+fi
+
+PREV_RELEASE=$(git describe --always --tags --abbrev=0 ${RELEASE}^)
+NOTABLE_CHANGES=$(git cat-file -p ${RELEASE} | sed '/-----BEGIN PGP SIGNATURE-----/,//d' | tail -n +6)
+CHANGELOG=$(git log --no-merges --pretty=format:'- [%h] %s (%aN)' ${PREV_RELEASE}..${RELEASE})
+if [[ $? -ne 0 ]]; then
+	echo "Error creating changelog"
+	exit 1
+fi
+
+cat <<EOF
+${NOTABLE_CHANGES}
+
+## Installation
+
+Download Knative event sources for AWS ${RELEASE}
+
+- [awscodecommit (linux/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awscodecommit-linux-amd64)
+- [awscodecommit (macos/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awscodecommit-darwin-amd64)
+- [awscognito (linux/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awscognito-linux-amd64)
+- [awscognito (macos/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awscognito-darwin-amd64)
+- [awsdynamodb (linux/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awsdynamodb-linux-amd64)
+- [awsdynamodb (macos/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awsdynamodb-darwin-amd64)
+- [awskinesis (linux/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awskinesis-linux-amd64)
+- [awskinesis (macos/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awskinesis-darwin-amd64)
+- [awssqs (linux/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awssqs-linux-amd64)
+- [awssqs (macos/amd64)](https://github.com/triggermesh/triggerflow/releases/download/${RELEASE}/awssqs-darwin-amd64)
+
+## Changelog
+
+${CHANGELOG}
+EOF


### PR DESCRIPTION
- Improvements in build system
	- Added `release` make target to generate binaries for linux and osx
	- Fixed list template in `fmt` and `fmt-test` makefile targets
	- Added `_KANIKO_NO_PUSH` flag to `cloudbuild.yml` for disabling docker push (used in `build` job)
	- Added `script/release-notes.sh` to generate release notes (used in `release` job)
	- General cleanup

- Improvements in CI pipeline
	- Use of Circle CI orbs
	- Removed `checkout-code` job
	- Validate `cloudbuild.yaml` and `Dockerfile`'s
	- Added `release` job to cut github releases