### PR TITLE
set a subject to be compatible with argo sensors

### DIFF
--- a/awssqs/main.go
+++ b/awssqs/main.go
@@ -198,6 +198,7 @@ func (clients Clients) sendSQSEvent(msg *sqs.Message, queueARN *string) error {
 
 	event := cloudevents.NewEvent("1.0")
 	event.SetType("com.amazon.sqs.message")
+	event.SetSubject("triggermesh")
 	event.SetSource(queueURL)
 	event.SetID(*msg.MessageId)
 	event.SetDataContentType(cloudevents.ApplicationJSON)


### PR DESCRIPTION
Just a quick one to discuss the use of CE subject.

If we could use a sane default it would make our sources compatible with argo-sensors.