### PR TITLE
Remove calls to UpdateStatus

### DIFF
--- a/pkg/reconciler/awscodecommitsource/controller.go
+++ b/pkg/reconciler/awscodecommitsource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscodecommitsource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscodecommitsource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSCodeCommitSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awscodecommitsource/reconciler.go
+++ b/pkg/reconciler/awscodecommitsource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscodecommitsource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSCodeCommitSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSCodeCommi
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awscodecommitsource/status.go
+++ b/pkg/reconciler/awscodecommitsource/status.go
@@ -18,57 +18,33 @@ package awscodecommitsource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSCodeCommitSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSCodeCommitSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSCodeCommitSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSCodeCommitSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSCodeCommitSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSCodeCommitSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSCodeCommitSourceSpec) []duckv1.CloudEventAttributes {
 	ceAttributes := make([]duckv1.CloudEventAttributes, len(srcSpec.EventTypes))
 	for i, typ := range srcSpec.EventTypes {
 		ceAttributes[i] = duckv1.CloudEventAttributes{

--- a/pkg/reconciler/awscognitosource/controller.go
+++ b/pkg/reconciler/awscognitosource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscognitosource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscognitosource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSCognitoSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awscognitosource/reconciler.go
+++ b/pkg/reconciler/awscognitosource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscognitosource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSCognitoSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSCognitoSo
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awscognitosource/status.go
+++ b/pkg/reconciler/awscognitosource/status.go
@@ -18,57 +18,33 @@ package awscognitosource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSCognitoSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSCognitoSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSCognitoSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSCognitoSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSCognitoSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSCognitoSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSCognitoSourceSpec) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
 			Type:   v1alpha1.AWSCognitoEventType(v1alpha1.AWSCognitoGenericEventType),

--- a/pkg/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/reconciler/awsdynamodbsource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awsdynamodbsource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsdynamodbsource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSDynamoDBSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awsdynamodbsource/reconciler.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsdynamodbsource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSDynamoDBSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSDynamoDBS
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awsdynamodbsource/status.go
+++ b/pkg/reconciler/awsdynamodbsource/status.go
@@ -18,57 +18,33 @@ package awsdynamodbsource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSDynamoDBSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSDynamoDBSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSDynamoDBSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSDynamoDBSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSDynamoDBSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSDynamoDBSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSDynamoDBSourceSpec) []duckv1.CloudEventAttributes {
 	types := v1alpha1.AWSDynamoDBEventTypes()
 	ceAttributes := make([]duckv1.CloudEventAttributes, len(types))
 	for i, typ := range types {

--- a/pkg/reconciler/awsiotsource/controller.go
+++ b/pkg/reconciler/awsiotsource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awsiotsource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsiotsource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSIoTSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awsiotsource/reconciler.go
+++ b/pkg/reconciler/awsiotsource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsiotsource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSIoTSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSIoTSource
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awskinesissource/controller.go
+++ b/pkg/reconciler/awskinesissource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awskinesissource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awskinesissource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSKinesisSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awskinesissource/reconciler.go
+++ b/pkg/reconciler/awskinesissource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awskinesissource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSKinesisSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSKinesisSo
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awskinesissource/status.go
+++ b/pkg/reconciler/awskinesissource/status.go
@@ -18,57 +18,33 @@ package awskinesissource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSKinesisSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSKinesisSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSKinesisSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSKinesisSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSKinesisSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSKinesisSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSKinesisSourceSpec) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
 			Type:   v1alpha1.AWSKinesisEventType(v1alpha1.AWSKinesisGenericEventType),

--- a/pkg/reconciler/awssnssource/controller.go
+++ b/pkg/reconciler/awssnssource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awssnssource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSSNSSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awssnssource/reconciler.go
+++ b/pkg/reconciler/awssnssource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSSNSSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSSNSSource
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awssnssource/status.go
+++ b/pkg/reconciler/awssnssource/status.go
@@ -18,57 +18,33 @@ package awssnssource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSSNSSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSSNSSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSSNSSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSSNSSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSSNSSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSSNSSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSSNSSourceSpec) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
 			Type:   v1alpha1.AWSSNSEventType(v1alpha1.AWSKinesisGenericEventType),

--- a/pkg/reconciler/awssqssource/controller.go
+++ b/pkg/reconciler/awssqssource/controller.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
 	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awssqssource"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssqssource"
 )
@@ -56,7 +55,6 @@ func NewController(
 	r := &Reconciler{
 		logger:           logger,
 		adapterCfg:       adapterCfg,
-		sourceClient:     client.Get(ctx).SourcesV1alpha1().AWSSQSSources,
 		deploymentClient: k8sclient.Get(ctx).AppsV1().Deployments,
 		deploymentLister: deploymentInformer.Lister().Deployments,
 	}

--- a/pkg/reconciler/awssqssource/reconciler.go
+++ b/pkg/reconciler/awssqssource/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssqssource"
 )
 
@@ -44,7 +43,6 @@ type Reconciler struct {
 	adapterCfg *adapterConfig
 
 	// API clients
-	sourceClient     func(namespace string) clientv1alpha1.AWSSQSSourceInterface
 	deploymentClient func(namespace string) appsclientv1.DeploymentInterface
 
 	// objects listers
@@ -64,7 +62,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSSQSSource
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 
-	return r.syncStatus(o, adapter)
+	r.computeStatus(o, adapter)
+
+	return nil
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awssqssource/status.go
+++ b/pkg/reconciler/awssqssource/status.go
@@ -18,57 +18,33 @@ package awssqssource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// syncStatus ensures the status of a given source is up-to-date.
-func (r *Reconciler) syncStatus(src *v1alpha1.AWSSQSSource, adapter *appsv1.Deployment) error {
-	currentStatus := &src.Status
-	expectedStatus := r.computeStatus(src, adapter)
-
-	if equality.Semantic.DeepEqual(expectedStatus, currentStatus) {
-		return nil
-	}
-
-	src = &v1alpha1.AWSSQSSource{
-		ObjectMeta: src.ObjectMeta,
-		Status:     *expectedStatus,
-	}
-
-	_, err := r.sourceClient(src.Namespace).UpdateStatus(src)
-	return err
-}
-
-// computeStatus returns the expected status of a given source.
-func (r *Reconciler) computeStatus(src *v1alpha1.AWSSQSSource,
-	adapter *appsv1.Deployment) *v1alpha1.AWSSQSSourceStatus {
-
-	status := src.Status.DeepCopy()
-	status.InitializeConditions()
-	status.CloudEventAttributes = r.createCloudEventAttributes(&src.Spec)
-	status.ObservedGeneration = src.Generation
+// computeStatus sets the attributes and conditions of the sources's status.
+func (r *Reconciler) computeStatus(src *v1alpha1.AWSSQSSource, adapter *appsv1.Deployment) {
+	src.Status.InitializeConditions()
+	src.Status.CloudEventAttributes = createCloudEventAttributes(&src.Spec)
+	src.Status.ObservedGeneration = src.Generation
 
 	sinkURI, err := r.sinkResolver.URIFromDestinationV1(src.Spec.Sink, src)
 	if err != nil {
-		status.MarkNoSink()
-		return status
+		src.Status.MarkNoSink()
+		return
 	}
-	status.MarkSink(sinkURI)
+	src.Status.MarkSink(sinkURI)
 
 	if adapter != nil {
-		status.PropagateAvailability(adapter)
+		src.Status.PropagateAvailability(adapter)
 	}
-
-	return status
 }
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func (r *Reconciler) createCloudEventAttributes(srcSpec *v1alpha1.AWSSQSSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(srcSpec *v1alpha1.AWSSQSSourceSpec) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
 			Type:   v1alpha1.AWSSQSEventType(v1alpha1.AWSSQSGenericEventType),


### PR DESCRIPTION
We were re-implementing something that is already done by the parent (generated) Reconciler, so this entire logic can go away.

Closes #109