### PR TITLE
build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ workflows:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - build:
+          context: production
           requires:
             - checkout
           filters:
@@ -117,6 +118,7 @@ workflows:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - publish:
+          context: production
           requires:
             - build
             - test
@@ -126,6 +128,7 @@ workflows:
             branches:
               only: master
       - release:
+          context: production
           requires:
             - publish
           filters:

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,9 @@
 **/c.out
 **/*-coverage.html
 **/*-unit-tests.xml
+**/Dockerfile
+**/*-linux-amd64
+**/*-darwin-amd64
 
 # Binaries
 /cmd/aws-event-sources-controller/aws-event-sources-controller

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,1 +1,2 @@
 #!include:.dockerignore
+!**/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 *~
 *.swp
 *.swo
+
+# Build artifacts
+**/*-linux-amd64
+**/*-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ coverage: ## Generate code coverage
 	$(GOTOOL) cover -html=c.out -o $(OUTPUT_DIR)$(PACKAGE)-coverage.html
 
 lint:
-	$(GOLINT) $(GOPKGS)
+	$(GOLINT) -set_exit_status $(GOPKGS)
 
 vet:
 	$(GO) vet $(GOPKGS)

--- a/scripts/inc.Makefile
+++ b/scripts/inc.Makefile
@@ -13,7 +13,7 @@ GO         ?= go
 GOFMT      ?= gofmt
 GOLINT     ?= golint
 GOTOOL     ?= go tool
-GOTEST     ?= gotestsum --junitfile $(OUTPUT_DIR)$(PACKAGE)-unit-tests.xml --
+GOTEST     ?= gotestsum --junitfile $(OUTPUT_DIR)$(PACKAGE)-unit-tests.xml --format pkgname-and-test-fails --
 
 GOPKGS      = ./...
 LDFLAGS     =


### PR DESCRIPTION
- ci: use env variables from org contexts
- add release binaries to git ignore rules
- test: increase verbosity of `gotestsum` failures
- docker: exclude release binaries from docker build context
- lint: enforce linter errors