### PR TITLE
Use empty logging config in docs

### DIFF
--- a/cmd/awscodecommitsource/README.md
+++ b/cmd/awscodecommitsource/README.md
@@ -86,7 +86,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awscodecommitsource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awscodecommitsource", "configMap":{}}'
 ```
 
@@ -110,7 +110,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awscodecommitsource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awscodecommitsource", "configMap":{}}' \
   gcr.io/triggermesh/awscodecommitsource:latest
 ```

--- a/cmd/awscognitosource/README.md
+++ b/cmd/awscognitosource/README.md
@@ -83,7 +83,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awscognitosource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awscognitosource", "configMap":{}}'
 ```
 
@@ -104,7 +104,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awscognitosource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awscognitosource", "configMap":{}}' \
   gcr.io/triggermesh/awscognitosource:latest
 ```

--- a/cmd/awsdynamodbsource/README.md
+++ b/cmd/awsdynamodbsource/README.md
@@ -84,7 +84,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awsdynamodbsource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awsdynamodbsource", "configMap":{}}'
 ```
 
@@ -106,7 +106,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awsdynamodbsource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awsdynamodbsource", "configMap":{}}' \
   gcr.io/triggermesh/awsdynamodbsource:latest
 ```

--- a/cmd/awskinesissource/README.md
+++ b/cmd/awskinesissource/README.md
@@ -83,7 +83,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awskinesissource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awskinesissource", "configMap":{}}'
 ```
 
@@ -105,7 +105,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awskinesissource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awskinesissource", "configMap":{}}' \
   gcr.io/triggermesh/awskinesissource:latest
 ```

--- a/cmd/awssnssource/README.md
+++ b/cmd/awssnssource/README.md
@@ -95,7 +95,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awssnssource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awssnssource", "configMap":{}}'
 ```
 
@@ -117,7 +117,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awssnssource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awssnssource", "configMap":{}}' \
   gcr.io/triggermesh/awssnssource:latest
 ```

--- a/cmd/awssqssource/README.md
+++ b/cmd/awssqssource/README.md
@@ -82,7 +82,7 @@ export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awssqssource
 export NAMESPACE=default
-export K_LOGGING_CONFIG='{"level":"info"}'
+export K_LOGGING_CONFIG=''
 export K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awssqssource", "configMap":{}}'
 ```
 
@@ -104,7 +104,7 @@ $ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awssqssource \
   -e NAMESPACE=default \
-  -e K_LOGGING_CONFIG='{"level":"info"}' \
+  -e K_LOGGING_CONFIG='' \
   -e K_METRICS_CONFIG='{"domain":"triggermesh.io/sources", "component":"awssqssource", "configMap":{}}' \
   gcr.io/triggermesh/awssqssource:latest
 ```

--- a/config/samples/awscodecommit-containersource.yaml
+++ b/config/samples/awscodecommit-containersource.yaml
@@ -60,10 +60,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awscodecommit-sinkbinding.yaml
+++ b/config/samples/awscodecommit-sinkbinding.yaml
@@ -86,10 +86,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awscognito-containersource.yaml
+++ b/config/samples/awscognito-containersource.yaml
@@ -51,10 +51,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awscognito-sinkbinding.yaml
+++ b/config/samples/awscognito-sinkbinding.yaml
@@ -77,10 +77,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awsdynamodb-containersource.yaml
+++ b/config/samples/awsdynamodb-containersource.yaml
@@ -54,10 +54,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awsdynamodb-sinkbinding.yaml
+++ b/config/samples/awsdynamodb-sinkbinding.yaml
@@ -80,10 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awskinesis-containersource.yaml
+++ b/config/samples/awskinesis-containersource.yaml
@@ -54,10 +54,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awskinesis-sinkbinding.yaml
+++ b/config/samples/awskinesis-sinkbinding.yaml
@@ -80,10 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awssns-containersource.yaml
+++ b/config/samples/awssns-containersource.yaml
@@ -54,10 +54,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awssns-sinkbinding.yaml
+++ b/config/samples/awssns-sinkbinding.yaml
@@ -80,10 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awssqs-containersource.yaml
+++ b/config/samples/awssqs-containersource.yaml
@@ -54,10 +54,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {

--- a/config/samples/awssqs-sinkbinding.yaml
+++ b/config/samples/awssqs-sinkbinding.yaml
@@ -80,10 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K_LOGGING_CONFIG
-          value: |
-            {
-              "level": "info"
-            }
+          value: ''
         - name: K_METRICS_CONFIG
           value: |
             {


### PR DESCRIPTION
The previous value didn't have the correct format, and a Zap configuration needs to contain [much more than just a loglevel](https://github.com/knative/pkg/blob/release-0.14/logging/config.go#L132-L151) to be parsed successfully. (e.g. `encoderConfig` must contain all the required attributes)

Instead of suggesting users to set gigantic and unreadable env vars, I suggest we use an empty string in docs and samples, which would fall back to the defaults linked above.