### PR TITLE
Revert "ci: create prospective merge branch for running the ci tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   go: circleci/go@1.1.1
   gcp-cli: circleci/gcp-cli@1.8.4
-  ghpr: narrativescience/ghpr@0.1.0
 
 jobs:
   checkout:
@@ -11,10 +10,7 @@ jobs:
       name: go/default
       tag: '1.14'
     steps:
-      - ghpr/build-prospective-branch
-      - ghpr/post-pr-comment:
-          comment: ":dog: The CI job was __aborted__ because we __failed to create a prospective merge branch__. Please __resolve the merge conflicts__."
-          when: on_fail
+      - checkout
       - go/mod-download-cached
       - persist_to_workspace:
           root: ~/
@@ -105,7 +101,6 @@ workflows:
   build-test-and-publish:
     jobs:
       - checkout:
-          context: production
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/


### PR DESCRIPTION
`ghpr/build-prospective-branch` step tries to build a merge branch when
we're on the `master` and fails while trying to find the base branch.
Reverting this change so that the pipeline is operational

This reverts commit c8ad0d6fafad0f19e549c8fb3a0ecdff1425a1db.