### PR TITLE
Add structural OpenAPI schemas to all CRDs

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -16,8 +16,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: aws-event-sources-controller
-  labels:
-    eventing.knative.dev/release: devel
 rules:
 
 # Record Kubernetes events

--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -17,8 +17,6 @@ kind: ServiceAccount
 metadata:
   name: aws-event-sources-controller
   namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
 
 ---
 
@@ -26,8 +24,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: &app aws-event-sources-controller
-  labels:
-    eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: *app

--- a/config/300-awscodecommit.yaml
+++ b/config/300-awscodecommit.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awscodecommitsources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -50,10 +49,127 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              repository:
+                type: string
+              branch:
+                type: string
+              region:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+              eventTypes:
+                type: array
+                items:
+                  type: string
+                  enum: [push, pull_request]
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - repository
+            - branch
+            - region
+            - eventTypes
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awscognito.yaml
+++ b/config/300-awscognito.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awscognitosources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -49,10 +48,115 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              identityPoolID:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d:[a-z0-9-]+$'
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - identityPoolID
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awsdynamodb.yaml
+++ b/config/300-awsdynamodb.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awsdynamodbsources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -51,10 +50,118 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              table:
+                type: string
+              region:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - table
+            - region
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awsiot.yaml
+++ b/config/300-awsiot.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awsiotsources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -49,10 +48,99 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              endpoint:
+                type: string
+                format: hostname
+              topic:
+                type: string
+              rootCA:
+                type: string
+              rootCAPath:
+                type: string
+              certificate:
+                type: string
+              certificatePath:
+                type: string
+              privateKey:
+                type: string
+              privateKeyPath:
+                type: string
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - endpoint
+            - topic
+            - rootCA
+            - certificate
+            - privateKey
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awskinesis.yaml
+++ b/config/300-awskinesis.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awskinesissources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -49,10 +48,118 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              stream:
+                type: string
+              region:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - stream
+            - region
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awssns.yaml
+++ b/config/300-awssns.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awssnssources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -49,10 +48,118 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              topic:
+                type: string
+              region:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - topic
+            - region
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/300-awssqs.yaml
+++ b/config/300-awssqs.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: awssqssources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: 'true'
     duck.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
@@ -49,10 +48,118 @@ spec:
         properties:
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              queue:
+                type: string
+              region:
+                type: string
+                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+              credentials:
+                type: object
+                properties:
+                  accessKeyID:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+                  secretAccessKey:
+                    type: object
+                    properties:
+                      value:
+                        type: string
+                        format: password
+                      valueFromSecret:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                    oneOf:
+                    - required: ['value']
+                    - required: ['valueFromSecret']
+              sink:
+                type: object
+                properties:
+                  ref:
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - queue
+            - region
+            - sink
           status:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
     additionalPrinterColumns:
     - name: Ready
       type: string

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -17,8 +17,6 @@ kind: Deployment
 metadata:
   name: &app aws-event-sources-controller
   namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
 
 spec:
   replicas: 1
@@ -30,7 +28,6 @@ spec:
     metadata:
       labels:
         app: *app
-        eventing.knative.dev/release: devel
 
     spec:
       serviceAccountName: *app

--- a/config/samples/awscognitosource.yaml
+++ b/config/samples/awscognitosource.yaml
@@ -19,7 +19,7 @@ kind: AWSCognitoSource
 metadata:
   name: sample
 spec:
-  identityPoolId: us-west-2:2f266209-2504-4f0c-9c8b-1e37c4344917
+  identityPoolID: us-west-2:2f266209-2504-4f0c-9c8b-1e37c4344917
 
   credentials:
     accessKeyID:


### PR DESCRIPTION
Validates the structure of `spec` and `status`, ensures all `required` fields are defined before ingestion, and performs some field validation whenever possible

Closes #65