### PR TITLE
Use ARN instead of individual params in CRDs

### DIFF
--- a/cmd/awscodecommitsource/README.md
+++ b/cmd/awscodecommitsource/README.md
@@ -36,8 +36,8 @@ The _AWS CodeCommit event source_ can be deployed to Kubernetes in different man
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSCodeCommitSource object
 
@@ -78,10 +78,9 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export REPO=<my_codecommit_repo>
+export ARN=<arn_of_my_codecommit_repo>
 export BRANCH=<my_git_branch>
 export EVENT_TYPES=push,pull_request
-export AWS_REGION=<my_repo_region>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awscodecommitsource
@@ -102,10 +101,9 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e REPO=<my_codecommit_repo> \
+  -e ARN=<arn_of_my_codecommit_repo> \
   -e BRANCH=<my_git_branch> \
   -e EVENT_TYPES=push,pull_request \
-  -e AWS_REGION=<my_repo_region> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awscodecommitsource \

--- a/cmd/awscognitosource/README.md
+++ b/cmd/awscognitosource/README.md
@@ -36,8 +36,8 @@ The _AWS Cognito event source_ can be deployed to Kubernetes in different manner
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSCognitoSource object
 
@@ -78,7 +78,7 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export IDENTITY_POOL_ID=<my_identity_pool_id>
+export ARN=<arn_of_my_identity_pool>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awscognitosource
@@ -99,7 +99,7 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e IDENTITY_POOL_ID=<my_identity_pool_id> \
+  -e ARN=<arn_of_my_identity_pool> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awscognitosource \

--- a/cmd/awsdynamodbsource/README.md
+++ b/cmd/awsdynamodbsource/README.md
@@ -36,8 +36,8 @@ The _AWS DynamoDB event source_ can be deployed to Kubernetes in different manne
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSDynamoDBSource object
 
@@ -78,8 +78,7 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export TABLE=<my_dynamodb_table>
-export AWS_REGION=<my_table_region>
+export ARN=<arn_of_my_dynamodb_table>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awsdynamodbsource
@@ -100,8 +99,7 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e TABLE=<my_dynamodb_table> \
-  -e AWS_REGION=<my_table_region> \
+  -e ARN=<arn_of_my_dynamodb_table> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awsdynamodbsource \

--- a/cmd/awskinesissource/README.md
+++ b/cmd/awskinesissource/README.md
@@ -35,8 +35,8 @@ The _AWS Kinesis event source_ can be deployed to Kubernetes in different manner
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSKinesisSource object
 
@@ -77,8 +77,7 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export STREAM=<my_kinesis_stream>
-export AWS_REGION=<my_stream_region>
+export ARN=<arn_of_my_kinesis_stream>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awskinesissource
@@ -99,8 +98,7 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e STREAM=<my_kinesis_stream> \
-  -e AWS_REGION=<my_stream_region> \
+  -e ARN=<arn_of_my_kinesis_stream> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awskinesissource \

--- a/cmd/awssnssource/README.md
+++ b/cmd/awssnssource/README.md
@@ -48,8 +48,8 @@ The _AWS SNS event source_ can be deployed to Kubernetes in different manners:
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSSNSSource object
 
@@ -89,8 +89,7 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export TOPIC=<my_sns_topic>
-export AWS_REGION=<my_topic_region>
+export ARN=<arn_of_my_sns_topic>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awssnssource
@@ -111,8 +110,7 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e TOPIC=<my_sns_topic> \
-  -e AWS_REGION=<my_topic_region> \
+  -e ARN=<arn_of_my_sns_topic> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awssnssource \

--- a/cmd/awssqssource/README.md
+++ b/cmd/awssqssource/README.md
@@ -35,8 +35,8 @@ The _AWS SQS event source_ can be deployed to Kubernetes in different manners:
 >   --from-literal=aws_secret_access_key=<my_secret_key>
 > ```
 >
-> Alternatively, credentials can be used as literal strings instead of references by replacing `valueFrom` attributes
-> with `value`.
+> Alternatively, credentials can be used as literal strings instead of references to Kubernetes Secrets by replacing
+> `valueFrom` attributes with `value` inside API objects' manifests.
 
 ### As a AWSSQSSource object
 
@@ -76,8 +76,7 @@ Running the event source on your local machine can be convenient for development
 Ensure the following environment variables are exported to your current shell's environment:
 
 ```sh
-export QUEUE=<my_sqs_queue>
-export AWS_REGION=<my_queue_region>
+export ARN=<arn_of_my_sqs_queue>
 export AWS_ACCESS_KEY_ID=<my_key_id>
 export AWS_SECRET_ACCESS_KEY=<my_secret_key>
 export NAME=my-awssqssource
@@ -98,8 +97,7 @@ Using one of TriggerMesh's release images:
 
 ```console
 $ docker run --rm \
-  -e QUEUE=<my_sqs_queue> \
-  -e AWS_REGION=<my_queue_region> \
+  -e ARN=<arn_of_my_sqs_queue> \
   -e AWS_ACCESS_KEY_ID=<my_key_id> \
   -e AWS_SECRET_ACCESS_KEY=<my_secret_key> \
   -e NAME=my-awssqssource \

--- a/config/300-awscodecommit.yaml
+++ b/config/300-awscodecommit.yaml
@@ -50,13 +50,11 @@ spec:
           spec:
             type: object
             properties:
-              repository:
+              arn:
                 type: string
+                pattern: '^arn:aws(-cn|-us-gov)?:codecommit:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
               branch:
                 type: string
-              region:
-                type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
               eventTypes:
                 type: array
                 items:
@@ -121,9 +119,8 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - repository
+            - arn
             - branch
-            - region
             - eventTypes
             - sink
           status:

--- a/config/300-awscognito.yaml
+++ b/config/300-awscognito.yaml
@@ -49,9 +49,9 @@ spec:
           spec:
             type: object
             properties:
-              identityPoolID:
+              arn:
                 type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d:[a-z0-9-]+$'
+                pattern: '^arn:aws(-cn|-us-gov)?:cognito-identity:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:identitypool\/.+$'
               credentials:
                 type: object
                 properties:
@@ -111,7 +111,7 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - identityPoolID
+            - arn
             - sink
           status:
             type: object

--- a/config/300-awsdynamodb.yaml
+++ b/config/300-awsdynamodb.yaml
@@ -51,11 +51,9 @@ spec:
           spec:
             type: object
             properties:
-              table:
+              arn:
                 type: string
-              region:
-                type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+                pattern: '^arn:aws(-cn|-us-gov)?:dynamodb:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:table\/.+$'
               credentials:
                 type: object
                 properties:
@@ -115,8 +113,7 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - table
-            - region
+            - arn
             - sink
           status:
             type: object

--- a/config/300-awsiot.yaml
+++ b/config/300-awsiot.yaml
@@ -52,8 +52,9 @@ spec:
               endpoint:
                 type: string
                 format: hostname
-              topic:
+              arn:
                 type: string
+                pattern: '^arn:aws(-cn|-us-gov)?:iot:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:topic\/.+$'
               rootCA:
                 type: string
               rootCAPath:
@@ -92,7 +93,7 @@ spec:
                 - required: ['uri']
             required:
             - endpoint
-            - topic
+            - arn
             - rootCA
             - certificate
             - privateKey

--- a/config/300-awskinesis.yaml
+++ b/config/300-awskinesis.yaml
@@ -49,11 +49,9 @@ spec:
           spec:
             type: object
             properties:
-              stream:
+              arn:
                 type: string
-              region:
-                type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+                pattern: '^arn:aws(-cn|-us-gov)?:kinesis:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:stream\/.+$'
               credentials:
                 type: object
                 properties:
@@ -113,8 +111,7 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - stream
-            - region
+            - arn
             - sink
           status:
             type: object

--- a/config/300-awssns.yaml
+++ b/config/300-awssns.yaml
@@ -49,11 +49,9 @@ spec:
           spec:
             type: object
             properties:
-              topic:
+              arn:
                 type: string
-              region:
-                type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+                pattern: '^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
               credentials:
                 type: object
                 properties:
@@ -113,8 +111,7 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - topic
-            - region
+            - arn
             - sink
           status:
             type: object

--- a/config/300-awssqs.yaml
+++ b/config/300-awssqs.yaml
@@ -49,11 +49,9 @@ spec:
           spec:
             type: object
             properties:
-              queue:
+              arn:
                 type: string
-              region:
-                type: string
-                pattern: '^[a-z]{2}(-gov)?-[a-z]+-\d$'
+                pattern: '^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
               credentials:
                 type: object
                 properties:
@@ -113,8 +111,7 @@ spec:
                 - required: ['ref']
                 - required: ['uri']
             required:
-            - queue
-            - region
+            - arn
             - sink
           status:
             type: object

--- a/config/samples/awscodecommit-containersource.yaml
+++ b/config/samples/awscodecommit-containersource.yaml
@@ -28,17 +28,14 @@ spec:
         env:
 
         # CodeCommit repository
-        - name: REPO
-          value: triggermeshtest
+        - name: ARN
+          value: arn:aws:codecommit:us-west-2:123456789012:triggermeshtest
 
         - name: BRANCH
           value: master
 
         - name: EVENT_TYPES
           value: push,pull_request
-
-        - name: AWS_REGION
-          value: us-west-2
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awscodecommit-sinkbinding.yaml
+++ b/config/samples/awscodecommit-sinkbinding.yaml
@@ -54,17 +54,14 @@ spec:
         env:
 
         # CodeCommit repository
-        - name: REPO
-          value: triggermeshtest
+        - name: ARN
+          value: arn:aws:codecommit:us-west-2:123456789012:triggermeshtest
 
         - name: BRANCH
           value: master
 
         - name: EVENT_TYPES
           value: push,pull_request
-
-        - name: AWS_REGION
-          value: us-west-2
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awscodecommitsource.yaml
+++ b/config/samples/awscodecommitsource.yaml
@@ -19,9 +19,8 @@ kind: AWSCodeCommitSource
 metadata:
   name: sample
 spec:
-  repository: triggermeshtest
+  arn: arn:aws:codecommit:us-west-2:123456789012:triggermeshtest
   branch: master
-  region: us-west-2
 
   eventTypes:
     - push

--- a/config/samples/awscognito-containersource.yaml
+++ b/config/samples/awscognito-containersource.yaml
@@ -28,8 +28,8 @@ spec:
         env:
 
         # Cognito identity pool
-        - name: IDENTITY_POOL_ID
-          value: us-west-2:2f266209-2504-4f0c-9c8b-1e37c4344917
+        - name: ARN
+          value: arn:aws:cognito-identity:us-west-2:123456789012:identitypool/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awscognito-sinkbinding.yaml
+++ b/config/samples/awscognito-sinkbinding.yaml
@@ -54,8 +54,8 @@ spec:
         env:
 
         # Cognito identity pool
-        - name: IDENTITY_POOL_ID
-          value: us-west-2:2f266209-2504-4f0c-9c8b-1e37c4344917
+        - name: ARN
+          value: arn:aws:cognito-identity:us-west-2:123456789012:identitypool/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awscognitosource.yaml
+++ b/config/samples/awscognitosource.yaml
@@ -19,7 +19,7 @@ kind: AWSCognitoSource
 metadata:
   name: sample
 spec:
-  identityPoolID: us-west-2:2f266209-2504-4f0c-9c8b-1e37c4344917
+  arn: arn:aws:cognito-identity:us-west-2:123456789012:identitypool/triggermeshtest
 
   credentials:
     accessKeyID:

--- a/config/samples/awsdynamodb-containersource.yaml
+++ b/config/samples/awsdynamodb-containersource.yaml
@@ -28,11 +28,8 @@ spec:
         env:
 
         # DynamoDB table
-        - name: TABLE
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awsdynamodb-sinkbinding.yaml
+++ b/config/samples/awsdynamodb-sinkbinding.yaml
@@ -54,11 +54,8 @@ spec:
         env:
 
         # DynamoDB table
-        - name: TABLE
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awsdynamodbsource.yaml
+++ b/config/samples/awsdynamodbsource.yaml
@@ -19,8 +19,7 @@ kind: AWSDynamoDBSource
 metadata:
   name: sample
 spec:
-  table: triggermeshtest
-  region: us-west-2
+  arn: arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest
 
   credentials:
     accessKeyID:

--- a/config/samples/awskinesis-containersource.yaml
+++ b/config/samples/awskinesis-containersource.yaml
@@ -28,11 +28,8 @@ spec:
         env:
 
         # Kinesis stream
-        - name: STREAM
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:kinesis:us-west-2:123456789012:stream/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awskinesis-sinkbinding.yaml
+++ b/config/samples/awskinesis-sinkbinding.yaml
@@ -54,11 +54,8 @@ spec:
         env:
 
         # Kinesis stream
-        - name: STREAM
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:kinesis:us-west-2:123456789012:stream/triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awskinesissource.yaml
+++ b/config/samples/awskinesissource.yaml
@@ -19,8 +19,7 @@ kind: AWSKinesisSource
 metadata:
   name: sample
 spec:
-  stream: triggermeshtest
-  region: us-west-2
+  arn: arn:aws:kinesis:us-west-2:123456789012:stream/triggermeshtest
 
   credentials:
     accessKeyID:

--- a/config/samples/awssns-containersource.yaml
+++ b/config/samples/awssns-containersource.yaml
@@ -28,11 +28,8 @@ spec:
         env:
 
         # SNS topic
-        - name: TOPIC
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:sns:us-west-2:123456789012:triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awssns-sinkbinding.yaml
+++ b/config/samples/awssns-sinkbinding.yaml
@@ -54,11 +54,8 @@ spec:
         env:
 
         # SNS topic
-        - name: TOPIC
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:sns:us-west-2:123456789012:triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awssnssource.yaml
+++ b/config/samples/awssnssource.yaml
@@ -19,8 +19,7 @@ kind: AWSSNSSource
 metadata:
   name: sample
 spec:
-  topic: triggermeshtest
-  region: us-west-2
+  arn: arn:aws:sns:us-west-2:123456789012:triggermeshtest
 
   credentials:
     accessKeyID:

--- a/config/samples/awssqs-containersource.yaml
+++ b/config/samples/awssqs-containersource.yaml
@@ -28,11 +28,8 @@ spec:
         env:
 
         # SQS queue
-        - name: QUEUE
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:sqs:us-west-2:123456789012:triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awssqs-sinkbinding.yaml
+++ b/config/samples/awssqs-sinkbinding.yaml
@@ -54,11 +54,8 @@ spec:
         env:
 
         # SQS queue
-        - name: QUEUE
-          value: triggermeshtest
-
-        - name: AWS_REGION
-          value: us-west-2
+        - name: ARN
+          value: arn:aws:sqs:us-west-2:123456789012:triggermeshtest
 
         # AWS credentials
         - name: AWS_ACCESS_KEY_ID

--- a/config/samples/awssqssource.yaml
+++ b/config/samples/awssqssource.yaml
@@ -19,8 +19,7 @@ kind: AWSSQSSource
 metadata:
   name: sample
 spec:
-  queue: triggermeshtest
-  region: us-west-2
+  arn: arn:aws:sqs:us-west-2:123456789012:triggermeshtest
 
   credentials:
     accessKeyID:

--- a/pkg/adapter/awscognitosource/adapter.go
+++ b/pkg/adapter/awscognitosource/adapter.go
@@ -22,17 +22,20 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity/cognitoidentityiface"
 	"github.com/aws/aws-sdk-go/service/cognitosync"
 	"github.com/aws/aws-sdk-go/service/cognitosync/cognitosynciface"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/triggermesh/aws-event-sources/pkg/adapter/common"
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
@@ -41,8 +44,7 @@ import (
 type envConfig struct {
 	pkgadapter.EnvConfig
 
-	IdentityPoolID string `envconfig:"IDENTITY_POOL_ID" required:"true"`
-	AWSRegion      string `envconfig:"AWS_REGION" required:"true"`
+	ARN string `envconfig:"ARN" required:"true"`
 }
 
 // adapter implements the source's adapter.
@@ -53,8 +55,8 @@ type adapter struct {
 	cgnSyncClient     cognitosynciface.CognitoSyncAPI
 	ceClient          cloudevents.Client
 
+	arn            arn.ARN
 	identityPoolID string
-	awsRegion      string
 }
 
 // NewEnvConfig returns an accessor for the source's adapter envConfig.
@@ -68,18 +70,22 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	env := envAcc.(*envConfig)
 
-	// create Cognito clients
-	sess := session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(5)))
+	arn := common.MustParseARN(env.ARN)
+
+	cfg := session.Must(session.NewSession(aws.NewConfig().
+		WithRegion(arn.Region).
+		WithMaxRetries(5),
+	))
 
 	return &adapter{
 		logger: logger,
 
-		cgnIdentityClient: cognitoidentity.New(sess),
-		cgnSyncClient:     cognitosync.New(sess),
+		cgnIdentityClient: cognitoidentity.New(cfg),
+		cgnSyncClient:     cognitosync.New(cfg),
 		ceClient:          ceClient,
 
-		identityPoolID: env.IdentityPoolID,
-		awsRegion:      env.AWSRegion,
+		arn:            arn,
+		identityPoolID: common.MustParseCognitoResource(arn.Resource),
 	}
 }
 
@@ -203,15 +209,15 @@ func (a *adapter) sendCognitoEvent(dataset *cognitosync.Dataset, records []*cogn
 		LastModifiedDate: dataset.LastModifiedDate,
 		NumRecords:       dataset.NumRecords,
 		EventType:        aws.String("SyncTrigger"),
-		Region:           &a.awsRegion,
+		Region:           &a.arn.Region,
 		IdentityPoolID:   &a.identityPoolID,
 		DatasetRecords:   records,
 	}
 
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
-	event.SetType(v1alpha1.AWSCognitoEventType(v1alpha1.AWSCognitoGenericEventType))
-	event.SetSubject(a.identityPoolID)
-	event.SetSource(v1alpha1.AWSCognitoEventSource(a.identityPoolID))
+	event.SetType(v1alpha1.AWSEventType(a.arn.Service, v1alpha1.AWSCognitoGenericEventType))
+	event.SetSubject(*dataset.DatasetName)
+	event.SetSource(a.arn.String())
 	event.SetID(*dataset.IdentityId)
 	if err := event.SetData(cloudevents.ApplicationJSON, data); err != nil {
 		return fmt.Errorf("failed to set event data: %w", err)

--- a/pkg/adapter/awssqssource/adapter.go
+++ b/pkg/adapter/awssqssource/adapter.go
@@ -23,15 +23,18 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/triggermesh/aws-event-sources/pkg/adapter/common"
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
@@ -40,8 +43,7 @@ import (
 type envConfig struct {
 	pkgadapter.EnvConfig
 
-	Queue     string `envconfig:"QUEUE" required:"true"`
-	AWSRegion string `envconfig:"AWS_REGION" required:"true"`
+	ARN string `envconfig:"ARN" required:"true"`
 }
 
 // adapter implements the source's adapter.
@@ -51,8 +53,7 @@ type adapter struct {
 	sqsClient sqsiface.SQSAPI
 	ceClient  cloudevents.Client
 
-	queue     string
-	awsRegion string
+	arn arn.ARN
 }
 
 // NewEnvConfig returns an accessor for the source's adapter envConfig.
@@ -66,17 +67,20 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	env := envAcc.(*envConfig)
 
-	// create SQS client
-	sess := session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(5)))
+	arn := common.MustParseARN(env.ARN)
+
+	cfg := session.Must(session.NewSession(aws.NewConfig().
+		WithRegion(arn.Region).
+		WithMaxRetries(5),
+	))
 
 	return &adapter{
 		logger: logger,
 
-		sqsClient: sqs.New(sess),
+		sqsClient: sqs.New(cfg),
 		ceClient:  ceClient,
 
-		queue:     env.Queue,
-		awsRegion: env.AWSRegion,
+		arn: arn,
 	}
 }
 
@@ -84,9 +88,9 @@ const waitTimeoutSec = 20
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(stopCh <-chan struct{}) error {
-	url, err := a.queueLookup(a.queue)
+	url, err := a.queueLookup(a.arn.Resource)
 	if err != nil {
-		a.logger.Fatalw("Unable to find URL of SQS queue "+a.queue, zap.Error(err))
+		a.logger.Fatalw("Unable to find URL of SQS queue "+a.arn.Resource, zap.Error(err))
 	}
 
 	queueURL := *url.QueueUrl
@@ -169,13 +173,13 @@ func (a *adapter) sendSQSEvent(msg *sqs.Message, queueARN *string) error {
 		Md5OfBody:         msg.MD5OfBody,
 		EventSource:       aws.String("aws:sqs"),
 		EventSourceARN:    queueARN,
-		AwsRegion:         &a.awsRegion,
+		AwsRegion:         &a.arn.Region,
 	}
 
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
-	event.SetType(v1alpha1.AWSSQSEventType(v1alpha1.AWSSQSGenericEventType))
-	event.SetSource(v1alpha1.AWSSQSEventSource(a.awsRegion, a.queue))
+	event.SetType(v1alpha1.AWSEventType(a.arn.Service, v1alpha1.AWSSQSGenericEventType))
 	event.SetSubject(*msg.MessageId)
+	event.SetSource(a.arn.String())
 	event.SetID(*msg.MessageId)
 	if err := event.SetData(cloudevents.ApplicationJSON, data); err != nil {
 		return fmt.Errorf("failed to set event data: %w", err)

--- a/pkg/adapter/common/common.go
+++ b/pkg/adapter/common/common.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package common contains various helpers for adapters.
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+const (
+	expectCognitoResourceFmt  = "identitypool/${IdentityPoolId}"
+	expectDynamoDBResourceFmt = "table/${TableName}"
+	expectKinesisResourceFmt  = "stream/${StreamName}"
+)
+
+// MustParseARN parses an ARN and panics in case of error.
+func MustParseARN(arnStr string) arn.ARN {
+	arn, err := arn.Parse(arnStr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse %q: %s", arnStr, err))
+	}
+	return arn
+}
+
+// MustParseCognitoResource parses the resource segment of a Cognito ARN and
+// panics in case of error.
+func MustParseCognitoResource(resource string) string /*identityPoolId*/ {
+	elements, err := parseResource(resource, expectCognitoResourceFmt)
+	if err != nil {
+		panic(err)
+	}
+	return elements[0]
+}
+
+// MustParseDynamoDBResource parses the resource segment of a DynamoDB ARN and
+// panics in case of error.
+func MustParseDynamoDBResource(resource string) string /*table*/ {
+	elements, err := parseResource(resource, expectDynamoDBResourceFmt)
+	if err != nil {
+		panic(err)
+	}
+	return elements[0]
+}
+
+// MustParseKinesisResource parses the resource segment of a Kinesis ARN and
+// panics in case of error.
+func MustParseKinesisResource(resource string) string /*stream*/ {
+	elements, err := parseResource(resource, expectKinesisResourceFmt)
+	if err != nil {
+		panic(err)
+	}
+	return elements[0]
+}
+
+// parseResource parses the resource segment of a ARN and panics in case of
+// error. A ARN resource should have the format "key1/val1/key2/val2/...".
+func parseResource(resource, expectFormat string) ([]string, error) {
+	expectElements := strings.Split(expectFormat, "/")
+
+	sections := strings.Split(resource, "/")
+	if len(sections) != len(expectElements) {
+		return nil, newParseResourceError(expectFormat, resource)
+	}
+
+	// exclude keys, only count values
+	elements := make([]string, 0, len(expectElements)/2)
+
+	for i, sec := range sections {
+		// assert equality of keys (even indexes), we want them to
+		// match the expected format unconditionally
+		if i%2 == 0 {
+			if sec != expectElements[i] {
+				return nil, newParseResourceError(expectFormat, resource)
+			}
+			continue
+		}
+		elements = append(elements, sec)
+	}
+
+	return elements, nil
+}
+
+type parseResourceError struct {
+	expectedFormat string
+	gotInput       string
+}
+
+func newParseResourceError(expect, got string) error {
+	return &parseResourceError{
+		expectedFormat: expect,
+		gotInput:       got,
+	}
+}
+
+// Error implements the error interface.
+func (e *parseResourceError) Error() string {
+	return fmt.Sprintf("resource segment of ARN %q does not match expected format %q", e.gotInput, e.expectedFormat)
+}

--- a/pkg/adapter/common/common_test.go
+++ b/pkg/adapter/common/common_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustParseARN(t *testing.T) {
+	testCases := map[string]struct {
+		input       string
+		expectPanic bool
+	}{
+		"valid input": {
+			input:       "arn:::::",
+			expectPanic: false,
+		},
+		"invalid input": {
+			input:       "arn:",
+			expectPanic: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			var testFn assert.PanicTestFunc = func() {
+				// we do not test the output because the
+				// parsing logic belongs to the AWS SDK
+				_ = MustParseARN(tc.input)
+			}
+
+			if tc.expectPanic {
+				assert.PanicsWithValue(t, `failed to parse "`+tc.input+`": arn: not enough sections`, testFn)
+			} else {
+				assert.NotPanics(t, testFn)
+			}
+		})
+	}
+}
+
+func TestMustParseResource(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		fmt       string
+		expectErr bool
+		expect    []string
+	}{
+		"input matches format, single element": {
+			input:  "key/some-value",
+			fmt:    "key/val",
+			expect: []string{"some-value"},
+		},
+		"input matches format, multiple elements": {
+			input:  "key1/some-value/key2/some-other-value",
+			fmt:    "key1/val/key2/val",
+			expect: []string{"some-value", "some-other-value"},
+		},
+		"only keys matter in format": {
+			input:  "key1/some-value/key2/some-other-value",
+			fmt:    "key1//key2/",
+			expect: []string{"some-value", "some-other-value"},
+		},
+		"odd number of elements yields values only": {
+			input:  "key1/some-value/key2/some-other-value/key3",
+			fmt:    "key1/val/key2/val/key3",
+			expect: []string{"some-value", "some-other-value"},
+		},
+		"empty input": {
+			input:     "",
+			fmt:       "key/val",
+			expectErr: true,
+		},
+		"more elements than format expects": {
+			input:     "key1/some-value/key2",
+			fmt:       "key1/val",
+			expectErr: true,
+		},
+		"empty format": {
+			input:     "key1/some-value/key2",
+			fmt:       "",
+			expectErr: true,
+		},
+		"non-matching key": {
+			input:     "some-key/some-value",
+			fmt:       "key/val",
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			out, err := parseResource(tc.input, tc.fmt)
+
+			assert.Equal(t, tc.expect, out)
+
+			if tc.expectErr {
+				assert.EqualError(t, err, newParseResourceError(tc.fmt, tc.input).Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMustParseCognitoResource(t *testing.T) {
+	testCases := map[string]struct {
+		input       string
+		expect      string
+		expectPanic bool
+	}{
+		"valid input": {
+			input:  "identitypool/some-value",
+			expect: "some-value",
+		},
+		"invalid input": {
+			input:       "not-identitypool/some-value",
+			expectPanic: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			var out string
+			var testFn assert.PanicTestFunc = func() {
+				out = MustParseCognitoResource(tc.input)
+			}
+
+			if tc.expectPanic {
+				assert.PanicsWithError(t,
+					newParseResourceError(expectCognitoResourceFmt, tc.input).Error(), testFn)
+			} else {
+				assert.NotPanics(t, testFn)
+			}
+
+			assert.Equal(t, tc.expect, out)
+		})
+	}
+}
+
+func TestMustParseDynamoDBResource(t *testing.T) {
+	testCases := map[string]struct {
+		input       string
+		expect      string
+		expectPanic bool
+	}{
+		"valid input": {
+			input:  "table/some-value",
+			expect: "some-value",
+		},
+		"invalid input": {
+			input:       "not-table/some-value",
+			expectPanic: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			var out string
+			var testFn assert.PanicTestFunc = func() {
+				out = MustParseDynamoDBResource(tc.input)
+			}
+
+			if tc.expectPanic {
+				assert.PanicsWithError(t,
+					newParseResourceError(expectDynamoDBResourceFmt, tc.input).Error(), testFn)
+			} else {
+				assert.NotPanics(t, testFn)
+			}
+
+			assert.Equal(t, tc.expect, out)
+		})
+	}
+}
+
+func TestMustParseKinesisResource(t *testing.T) {
+	testCases := map[string]struct {
+		input       string
+		expect      string
+		expectPanic bool
+	}{
+		"valid input": {
+			input:  "stream/some-value",
+			expect: "some-value",
+		},
+		"invalid input": {
+			input:       "not-stream/some-value",
+			expectPanic: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			var out string
+			var testFn assert.PanicTestFunc = func() {
+				out = MustParseKinesisResource(tc.input)
+			}
+
+			if tc.expectPanic {
+				assert.PanicsWithError(t,
+					newParseResourceError(expectKinesisResourceFmt, tc.input).Error(), testFn)
+			} else {
+				assert.NotPanics(t, testFn)
+			}
+
+			assert.Equal(t, tc.expect, out)
+		})
+	}
+}

--- a/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSCodeCommitSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -30,16 +26,4 @@ func (s *AWSCodeCommitSource) GetGroupVersionKind() schema.GroupVersionKind {
 // GetUntypedSpec implements apis.HasSpec.
 func (s *AWSCodeCommitSource) GetUntypedSpec() interface{} {
 	return s.Spec
-}
-
-// AWSCodeCommitEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSCodeCommitEventSource(region, repo string) string {
-	return fmt.Sprintf("https://git-codecommit.%s.amazonaws.com/v1/repos/%s", region, repo)
-}
-
-// AWSCodeCommitEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSCodeCommitEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.codecommit.%s", eventType)
 }

--- a/pkg/apis/sources/v1alpha1/awscodecommit_types.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_types.go
@@ -51,14 +51,13 @@ var (
 type AWSCodeCommitSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// Name of the repository.
-	Repository string `json:"repository"`
+	// Repository ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscodecommit.html#awscodecommit-resources-for-iam-policies
+	ARN string `json:"arn"`
 	// Name of the Git branch this source observes.
 	Branch string `json:"branch"`
-	// Name of the AWS region where the repository is located.
-	Region string `json:"region"`
-
 	// List of event types that should be processed by the source.
+	// Valid values: [push, pull_request]
 	EventTypes []string `json:"eventTypes"`
 
 	// Credentials to interact with the AWS CodeCommit API.

--- a/pkg/apis/sources/v1alpha1/awscognito_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscognito_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSCognitoSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -32,19 +28,7 @@ func (s *AWSCognitoSource) GetUntypedSpec() interface{} {
 	return s.Spec
 }
 
-// AWSCognitoEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSCognitoEventSource(identityPoolID string) string {
-	return fmt.Sprintf("aws:cognito:identitypool/%s", identityPoolID)
-}
-
 // Supported event types
 const (
 	AWSCognitoGenericEventType = "sync_trigger"
 )
-
-// AWSCognitoEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSCognitoEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.cognito.%s", eventType)
-}

--- a/pkg/apis/sources/v1alpha1/awscognito_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognito_types.go
@@ -51,8 +51,9 @@ var (
 type AWSCognitoSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// ID number of the identity pool.
-	IdentityPoolID string `json:"identityPoolID"`
+	// Identity Pool ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncognitoidentity.html#amazoncognitoidentity-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Credentials to interact with the AWS Cognito API.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
@@ -51,11 +51,9 @@ var (
 type AWSDynamoDBSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// Name of the DynamoDB table
-	Table string `json:"table"`
-
-	// Name of the AWS region where the DynamoDB table is located.
-	Region string `json:"region"`
+	// Table ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazondynamodb.html#amazondynamodb-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Credentials to interact with the AWS Cognito API.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/awsiot_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsiot_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSIoTSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -32,14 +28,7 @@ func (s *AWSIoTSource) GetUntypedSpec() interface{} {
 	return s.Spec
 }
 
-// AWSIoTEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSIoTEventSource(endpoint, topic string) string {
-	return fmt.Sprintf("%s/%s", endpoint, topic)
-}
-
-// AWSIoTEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSIoTEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.iot.%s", eventType)
-}
+// Supported event types
+const (
+	AWSIoTGenericEventType = "greetings"
+)

--- a/pkg/apis/sources/v1alpha1/awsiot_types.go
+++ b/pkg/apis/sources/v1alpha1/awsiot_types.go
@@ -53,8 +53,9 @@ type AWSIoTSourceSpec struct {
 
 	// Host name of the endpoint the client connects to
 	Endpoint string `json:"endpoint"`
-	// Topic messages get published to
-	Topic string `json:"topic"`
+	// Topic ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awsiot.html#awsiot-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Contents of the root CA
 	RootCA ValueFromField `json:"rootCA"`

--- a/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSKinesisSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -32,19 +28,7 @@ func (s *AWSKinesisSource) GetUntypedSpec() interface{} {
 	return s.Spec
 }
 
-// AWSKinesisEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSKinesisEventSource(region, stream string) string {
-	return fmt.Sprintf("aws:kinesis:%s:stream/%s", region, stream)
-}
-
 // Supported event types
 const (
 	AWSKinesisGenericEventType = "stream_record"
 )
-
-// AWSKinesisEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSKinesisEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.kinesis.%s", eventType)
-}

--- a/pkg/apis/sources/v1alpha1/awskinesis_types.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_types.go
@@ -51,10 +51,9 @@ var (
 type AWSKinesisSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// Name of the AWS Kinesis data stream.
-	Stream string `json:"stream"`
-	// Name of the AWS region where the AWS Kinesis data stream is located.
-	Region string `json:"region"`
+	// Stream ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonkinesis.html#amazonkinesis-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Credentials to interact with the AWS Kinesis API.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSSNSSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -32,19 +28,7 @@ func (s *AWSSNSSource) GetUntypedSpec() interface{} {
 	return s.Spec
 }
 
-// AWSSNSEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSSNSEventSource(region, topic string) string {
-	return fmt.Sprintf("%s:topic/%s", region, topic)
-}
-
 // Supported event types
 const (
 	AWSSNSGenericEventType = "notification"
 )
-
-// AWSSNSEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSSNSEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.sns.%s", eventType)
-}

--- a/pkg/apis/sources/v1alpha1/awssns_types.go
+++ b/pkg/apis/sources/v1alpha1/awssns_types.go
@@ -51,10 +51,9 @@ var (
 type AWSSNSSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// Name of the AWS SNS topic.
-	Topic string `json:"topic"`
-	// Name of the AWS region where the AWS SNS topic is located.
-	Region string `json:"region"`
+	// Topic ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Credentials to interact with the AWS SNS API.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (s *AWSSQSSource) GetGroupVersionKind() schema.GroupVersionKind {
@@ -32,19 +28,7 @@ func (s *AWSSQSSource) GetUntypedSpec() interface{} {
 	return s.Spec
 }
 
-// AWSSQSEventSource returns a representation of the source suitable for
-// usage as a CloudEvent source.
-func AWSSQSEventSource(region, queue string) string {
-	return fmt.Sprintf("aws:sqs:%s:queue/%s", region, queue)
-}
-
 // Supported event types
 const (
 	AWSSQSGenericEventType = "message"
 )
-
-// AWSSQSEventType returns the given event type in a format suitable for
-// usage as a CloudEvent type.
-func AWSSQSEventType(eventType string) string {
-	return fmt.Sprintf("com.amazon.sqs.%s", eventType)
-}

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -51,10 +51,9 @@ var (
 type AWSSQSSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// Name of the AWS SQS queue.
-	Queue string `json:"queue"`
-	// Name of the AWS region where the AWS SQS queue is located.
-	Region string `json:"region"`
+	// Queue ARN
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies
+	ARN string `json:"arn"`
 
 	// Credentials to interact with the AWS SQS API.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -23,6 +23,12 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// AWSEventType returns an event type in a format suitable for usage as a
+// CloudEvent type attribute.
+func AWSEventType(awsService, eventType string) string {
+	return "com.amazon." + awsService + "." + eventType
+}
+
 // awsEventSourceConditionSet is a common set of conditions for AWS event
 // sources objects.
 var awsEventSourceConditionSet = apis.NewLivingConditionSet(

--- a/pkg/reconciler/awscodecommitsource/reconciler.go
+++ b/pkg/reconciler/awscodecommitsource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscodecommitsource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSCodeCommitSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn, o.Spec.EventTypes)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awscodecommitsource/status.go
+++ b/pkg/reconciler/awscodecommitsource/status.go
@@ -17,18 +17,20 @@ limitations under the License.
 package awscodecommitsource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSCodeCommitSourceSpec) []duckv1.CloudEventAttributes {
-	ceAttributes := make([]duckv1.CloudEventAttributes, len(srcSpec.EventTypes))
-	for i, typ := range srcSpec.EventTypes {
+func createCloudEventAttributes(arn arn.ARN, eventTypes []string) []duckv1.CloudEventAttributes {
+	ceAttributes := make([]duckv1.CloudEventAttributes, len(eventTypes))
+	for i, typ := range eventTypes {
 		ceAttributes[i] = duckv1.CloudEventAttributes{
-			Type:   v1alpha1.AWSCodeCommitEventType(typ),
-			Source: v1alpha1.AWSCodeCommitEventSource(srcSpec.Region, srcSpec.Repository),
+			Type:   v1alpha1.AWSEventType(arn.Service, typ),
+			Source: arn.String(),
 		}
 	}
 	return ceAttributes

--- a/pkg/reconciler/awscognitosource/reconciler.go
+++ b/pkg/reconciler/awscognitosource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscognitosource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSCognitoSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awscognitosource/status.go
+++ b/pkg/reconciler/awscognitosource/status.go
@@ -17,17 +17,19 @@ limitations under the License.
 package awscognitosource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSCognitoSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
-			Type:   v1alpha1.AWSCognitoEventType(v1alpha1.AWSCognitoGenericEventType),
-			Source: v1alpha1.AWSCognitoEventSource(srcSpec.IdentityPoolID),
+			Type:   v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSCognitoGenericEventType),
+			Source: arn.String(),
 		},
 	}
 }

--- a/pkg/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/reconciler/awsdynamodbsource/adapter.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,13 +42,6 @@ import (
 
 const adapterName = "awsdynamodbsource"
 
-const (
-	envTable           = "TABLE"
-	envRegion          = "AWS_REGION"
-	envAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
-
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -59,7 +54,7 @@ type adapterConfig struct {
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
+func (r *Reconciler) reconcileAdapter(ctx context.Context, arn arn.ARN) error {
 	o := object.FromContext(ctx).(*v1alpha1.AWSDynamoDBSource)
 
 	sinkRef := &o.Spec.Sink.Ref
@@ -76,7 +71,7 @@ func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
 	}
 	o.Status.MarkSink(sinkURI)
 
-	desiredAdapter := makeAdapterDeployment(ctx, sinkURI, r.adapterCfg)
+	desiredAdapter := makeAdapterDeployment(ctx, arn, sinkURI, r.adapterCfg)
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -142,7 +137,9 @@ func (r *Reconciler) syncAdapterDeployment(ctx context.Context,
 }
 
 // makeAdapterDeployment returns a Deployment object for the source's adapter.
-func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+func makeAdapterDeployment(ctx context.Context, arn arn.ARN,
+	sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+
 	o := object.FromContext(ctx).(*v1alpha1.AWSDynamoDBSource)
 	name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), o.Name)
 
@@ -168,17 +165,16 @@ func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *a
 
 		resource.Image(adapterCfg.Image),
 
-		resource.EnvVar(common.NameEnvVar, o.Name),
-		resource.EnvVar(common.NamespaceEnvVar, o.Namespace),
-		resource.EnvVar(common.SinkEnvVar, sinkURIStr),
-		resource.EnvVar(common.LoggingConfigEnvVar, adapterCfg.LoggingCfg),
-		resource.EnvVar(common.MetricsConfigEnvVar, adapterCfg.MetricsCfg),
-		resource.EnvVar(envTable, o.Spec.Table),
-		resource.EnvVar(envRegion, o.Spec.Region),
-		resource.EnvVarFromSecret(envAccessKeyID,
+		resource.EnvVar(common.EnvName, o.Name),
+		resource.EnvVar(common.EnvNamespace, o.Namespace),
+		resource.EnvVar(common.EnvSink, sinkURIStr),
+		resource.EnvVar(common.EnvLoggingConfig, adapterCfg.LoggingCfg),
+		resource.EnvVar(common.EnvMetricsConfig, adapterCfg.MetricsCfg),
+		resource.EnvVar(common.EnvARN, arn.String()),
+		resource.EnvVarFromSecret(common.EnvAccessKeyID,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-		resource.EnvVarFromSecret(envSecretAccessKey,
+		resource.EnvVarFromSecret(common.EnvSecretAccessKey,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
 	)

--- a/pkg/reconciler/awsdynamodbsource/reconciler.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsdynamodbsource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSDynamoDBSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,11 +57,10 @@ const (
 
 	tImg = "registry/image:tag"
 
-	tTable  = "triggermeshtest"
-	tRegion = "us-test-0"
-
 	tMetricsDomain = "testing"
 )
+
+var tARN = NewARN(dynamodb.ServiceName, "table/triggermeshtest")
 
 var tSinkURI = &apis.URL{
 	Scheme: "http",
@@ -288,8 +289,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSDynamoDBSource
 			UID:       tUID,
 		},
 		Spec: v1alpha1.AWSDynamoDBSourceSpec{
-			Table:  tTable,
-			Region: tRegion,
+			ARN: tARN.String(),
 			Credentials: v1alpha1.AWSSecurityCredentials{
 				AccessKeyID: v1alpha1.ValueFromField{
 					ValueFromSecret: tAccessKeyIDSelector,
@@ -311,7 +311,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSDynamoDBSource
 	}
 
 	if len(skipCEAtrributes) == 0 {
-		o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
+		o.Status.CloudEventAttributes = createCloudEventAttributes(tARN)
 	}
 
 	o.Status.InitializeConditions()
@@ -414,36 +414,33 @@ func newAdapterDeployment() *appsv1.Deployment {
 						Image: tImg,
 						Env: []corev1.EnvVar{
 							{
-								Name:  common.NameEnvVar,
+								Name:  common.EnvName,
 								Value: tName,
 							}, {
-								Name:  common.NamespaceEnvVar,
+								Name:  common.EnvNamespace,
 								Value: tNs,
 							}, {
-								Name:  common.SinkEnvVar,
+								Name:  common.EnvSink,
 								Value: tSinkURI.String(),
 							}, {
-								Name:  common.LoggingConfigEnvVar,
+								Name:  common.EnvLoggingConfig,
 								Value: `{"zap-logger-config":"{\"level\": \"info\"}"}`,
 							}, {
-								Name: common.MetricsConfigEnvVar,
+								Name: common.EnvMetricsConfig,
 								Value: `{"Domain":"` + tMetricsDomain + `",` +
 									`"Component":"` + adapterName + `",` +
 									`"PrometheusPort":0,` +
 									`"ConfigMap":{"metrics.backend":"prometheus"}}`,
 							}, {
-								Name:  envTable,
-								Value: tTable,
+								Name:  common.EnvARN,
+								Value: tARN.String(),
 							}, {
-								Name:  envRegion,
-								Value: tRegion,
-							}, {
-								Name: envAccessKeyID,
+								Name: common.EnvAccessKeyID,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tAccessKeyIDSelector,
 								},
 							}, {
-								Name: envSecretAccessKey,
+								Name: common.EnvSecretAccessKey,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tSecretAccessKeySelector,
 								},

--- a/pkg/reconciler/awsdynamodbsource/status.go
+++ b/pkg/reconciler/awsdynamodbsource/status.go
@@ -17,19 +17,21 @@ limitations under the License.
 package awsdynamodbsource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSDynamoDBSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
 	types := v1alpha1.AWSDynamoDBEventTypes()
 	ceAttributes := make([]duckv1.CloudEventAttributes, len(types))
 	for i, typ := range types {
 		ceAttributes[i] = duckv1.CloudEventAttributes{
-			Type:   v1alpha1.AWSDynamoDBEventType(typ),
-			Source: v1alpha1.AWSDynamoDBEventSource(srcSpec.Region, srcSpec.Table),
+			Type:   v1alpha1.AWSEventType(arn.Service, typ),
+			Source: arn.String(),
 		}
 	}
 	return ceAttributes

--- a/pkg/reconciler/awsiotsource/adapter.go
+++ b/pkg/reconciler/awsiotsource/adapter.go
@@ -19,6 +19,9 @@ package awsiotsource
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +66,7 @@ type adapterConfig struct {
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
+func (r *Reconciler) reconcileAdapter(ctx context.Context, arn arn.ARN) error {
 	o := object.FromContext(ctx).(*v1alpha1.AWSIoTSource)
 
 	sinkRef := &o.Spec.Sink.Ref
@@ -80,7 +83,7 @@ func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
 	}
 	o.Status.MarkSink(sinkURI)
 
-	desiredAdapter := makeAdapterDeployment(ctx, sinkURI, r.adapterCfg)
+	desiredAdapter := makeAdapterDeployment(ctx, arn, sinkURI, r.adapterCfg)
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -146,7 +149,9 @@ func (r *Reconciler) syncAdapterDeployment(ctx context.Context,
 }
 
 // makeAdapterDeployment returns a Deployment object for the source's adapter.
-func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+func makeAdapterDeployment(ctx context.Context, arn arn.ARN,
+	sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+
 	o := object.FromContext(ctx).(*v1alpha1.AWSIoTSource)
 	name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), o.Name)
 
@@ -172,13 +177,13 @@ func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *a
 
 		resource.Image(adapterCfg.Image),
 
-		resource.EnvVar(common.NameEnvVar, o.Name),
-		resource.EnvVar(common.NamespaceEnvVar, o.Namespace),
-		resource.EnvVar(common.SinkEnvVar, sinkURIStr),
-		resource.EnvVar(common.LoggingConfigEnvVar, adapterCfg.LoggingCfg),
-		resource.EnvVar(common.MetricsConfigEnvVar, adapterCfg.MetricsCfg),
+		resource.EnvVar(common.EnvName, o.Name),
+		resource.EnvVar(common.EnvNamespace, o.Namespace),
+		resource.EnvVar(common.EnvSink, sinkURIStr),
+		resource.EnvVar(common.EnvLoggingConfig, adapterCfg.LoggingCfg),
+		resource.EnvVar(common.EnvMetricsConfig, adapterCfg.MetricsCfg),
 		resource.EnvVar(envEndpoint, o.Spec.Endpoint),
-		resource.EnvVar(envTopic, o.Spec.Topic),
+		resource.EnvVar(envTopic, strings.TrimPrefix(arn.Resource, "topic/")),
 		resource.EnvVarFromSecret(envRootCA,
 			o.Spec.RootCA.ValueFromSecret.Name,
 			o.Spec.RootCA.ValueFromSecret.Key),

--- a/pkg/reconciler/awsiotsource/reconciler.go
+++ b/pkg/reconciler/awsiotsource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsiotsource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSIoTSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awskinesissource/adapter.go
+++ b/pkg/reconciler/awskinesissource/adapter.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,13 +42,6 @@ import (
 
 const adapterName = "awskinesissource"
 
-const (
-	envStream          = "STREAM"
-	envRegion          = "AWS_REGION"
-	envAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
-
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -59,7 +54,7 @@ type adapterConfig struct {
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
+func (r *Reconciler) reconcileAdapter(ctx context.Context, arn arn.ARN) error {
 	o := object.FromContext(ctx).(*v1alpha1.AWSKinesisSource)
 
 	sinkRef := &o.Spec.Sink.Ref
@@ -76,7 +71,7 @@ func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
 	}
 	o.Status.MarkSink(sinkURI)
 
-	desiredAdapter := makeAdapterDeployment(ctx, sinkURI, r.adapterCfg)
+	desiredAdapter := makeAdapterDeployment(ctx, arn, sinkURI, r.adapterCfg)
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -142,7 +137,9 @@ func (r *Reconciler) syncAdapterDeployment(ctx context.Context,
 }
 
 // makeAdapterDeployment returns a Deployment object for the source's adapter.
-func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+func makeAdapterDeployment(ctx context.Context, arn arn.ARN,
+	sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+
 	o := object.FromContext(ctx).(*v1alpha1.AWSKinesisSource)
 	name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), o.Name)
 
@@ -168,17 +165,16 @@ func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *a
 
 		resource.Image(adapterCfg.Image),
 
-		resource.EnvVar(common.NameEnvVar, o.Name),
-		resource.EnvVar(common.NamespaceEnvVar, o.Namespace),
-		resource.EnvVar(common.SinkEnvVar, sinkURIStr),
-		resource.EnvVar(common.LoggingConfigEnvVar, adapterCfg.LoggingCfg),
-		resource.EnvVar(common.MetricsConfigEnvVar, adapterCfg.MetricsCfg),
-		resource.EnvVar(envStream, o.Spec.Stream),
-		resource.EnvVar(envRegion, o.Spec.Region),
-		resource.EnvVarFromSecret(envAccessKeyID,
+		resource.EnvVar(common.EnvName, o.Name),
+		resource.EnvVar(common.EnvNamespace, o.Namespace),
+		resource.EnvVar(common.EnvSink, sinkURIStr),
+		resource.EnvVar(common.EnvLoggingConfig, adapterCfg.LoggingCfg),
+		resource.EnvVar(common.EnvMetricsConfig, adapterCfg.MetricsCfg),
+		resource.EnvVar(common.EnvARN, arn.String()),
+		resource.EnvVarFromSecret(common.EnvAccessKeyID,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-		resource.EnvVarFromSecret(envSecretAccessKey,
+		resource.EnvVarFromSecret(common.EnvSecretAccessKey,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
 	)

--- a/pkg/reconciler/awskinesissource/reconciler.go
+++ b/pkg/reconciler/awskinesissource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awskinesissource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSKinesisSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/reconciler/awskinesissource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/kinesis"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,11 +57,10 @@ const (
 
 	tImg = "registry/image:tag"
 
-	tStream = "triggermeshtest"
-	tRegion = "us-test-0"
-
 	tMetricsDomain = "testing"
 )
+
+var tARN = NewARN(kinesis.ServiceName, "stream/triggermeshtest")
 
 var tSinkURI = &apis.URL{
 	Scheme: "http",
@@ -288,8 +289,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSKinesisSource 
 			UID:       tUID,
 		},
 		Spec: v1alpha1.AWSKinesisSourceSpec{
-			Stream: tStream,
-			Region: tRegion,
+			ARN: tARN.String(),
 			Credentials: v1alpha1.AWSSecurityCredentials{
 				AccessKeyID: v1alpha1.ValueFromField{
 					ValueFromSecret: tAccessKeyIDSelector,
@@ -311,7 +311,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSKinesisSource 
 	}
 
 	if len(skipCEAtrributes) == 0 {
-		o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
+		o.Status.CloudEventAttributes = createCloudEventAttributes(tARN)
 	}
 
 	o.Status.InitializeConditions()
@@ -414,36 +414,33 @@ func newAdapterDeployment() *appsv1.Deployment {
 						Image: tImg,
 						Env: []corev1.EnvVar{
 							{
-								Name:  common.NameEnvVar,
+								Name:  common.EnvName,
 								Value: tName,
 							}, {
-								Name:  common.NamespaceEnvVar,
+								Name:  common.EnvNamespace,
 								Value: tNs,
 							}, {
-								Name:  common.SinkEnvVar,
+								Name:  common.EnvSink,
 								Value: tSinkURI.String(),
 							}, {
-								Name:  common.LoggingConfigEnvVar,
+								Name:  common.EnvLoggingConfig,
 								Value: `{"zap-logger-config":"{\"level\": \"info\"}"}`,
 							}, {
-								Name: common.MetricsConfigEnvVar,
+								Name: common.EnvMetricsConfig,
 								Value: `{"Domain":"` + tMetricsDomain + `",` +
 									`"Component":"` + adapterName + `",` +
 									`"PrometheusPort":0,` +
 									`"ConfigMap":{"metrics.backend":"prometheus"}}`,
 							}, {
-								Name:  envStream,
-								Value: tStream,
+								Name:  common.EnvARN,
+								Value: tARN.String(),
 							}, {
-								Name:  envRegion,
-								Value: tRegion,
-							}, {
-								Name: envAccessKeyID,
+								Name: common.EnvAccessKeyID,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tAccessKeyIDSelector,
 								},
 							}, {
-								Name: envSecretAccessKey,
+								Name: common.EnvSecretAccessKey,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tSecretAccessKeySelector,
 								},

--- a/pkg/reconciler/awskinesissource/status.go
+++ b/pkg/reconciler/awskinesissource/status.go
@@ -17,17 +17,19 @@ limitations under the License.
 package awskinesissource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSKinesisSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
-			Type:   v1alpha1.AWSKinesisEventType(v1alpha1.AWSKinesisGenericEventType),
-			Source: v1alpha1.AWSKinesisEventSource(srcSpec.Region, srcSpec.Stream),
+			Type:   v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSKinesisGenericEventType),
+			Source: arn.String(),
 		},
 	}
 }

--- a/pkg/reconciler/awssnssource/adapter.go
+++ b/pkg/reconciler/awssnssource/adapter.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,13 +42,6 @@ import (
 
 const adapterName = "awssnssource"
 
-const (
-	envTopic           = "TOPIC"
-	envRegion          = "AWS_REGION"
-	envAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
-
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -59,7 +54,7 @@ type adapterConfig struct {
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
+func (r *Reconciler) reconcileAdapter(ctx context.Context, arn arn.ARN) error {
 	o := object.FromContext(ctx).(*v1alpha1.AWSSNSSource)
 
 	sinkRef := &o.Spec.Sink.Ref
@@ -76,7 +71,7 @@ func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
 	}
 	o.Status.MarkSink(sinkURI)
 
-	desiredAdapter := makeAdapterDeployment(ctx, sinkURI, r.adapterCfg)
+	desiredAdapter := makeAdapterDeployment(ctx, arn, sinkURI, r.adapterCfg)
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -142,7 +137,9 @@ func (r *Reconciler) syncAdapterDeployment(ctx context.Context,
 }
 
 // makeAdapterDeployment returns a Deployment object for the source's adapter.
-func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+func makeAdapterDeployment(ctx context.Context, arn arn.ARN,
+	sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+
 	o := object.FromContext(ctx).(*v1alpha1.AWSSNSSource)
 	name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), o.Name)
 
@@ -168,17 +165,16 @@ func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *a
 
 		resource.Image(adapterCfg.Image),
 
-		resource.EnvVar(common.NameEnvVar, o.Name),
-		resource.EnvVar(common.NamespaceEnvVar, o.Namespace),
-		resource.EnvVar(common.SinkEnvVar, sinkURIStr),
-		resource.EnvVar(common.LoggingConfigEnvVar, adapterCfg.LoggingCfg),
-		resource.EnvVar(common.MetricsConfigEnvVar, adapterCfg.MetricsCfg),
-		resource.EnvVar(envTopic, o.Spec.Topic),
-		resource.EnvVar(envRegion, o.Spec.Region),
-		resource.EnvVarFromSecret(envAccessKeyID,
+		resource.EnvVar(common.EnvName, o.Name),
+		resource.EnvVar(common.EnvNamespace, o.Namespace),
+		resource.EnvVar(common.EnvSink, sinkURIStr),
+		resource.EnvVar(common.EnvLoggingConfig, adapterCfg.LoggingCfg),
+		resource.EnvVar(common.EnvMetricsConfig, adapterCfg.MetricsCfg),
+		resource.EnvVar(common.EnvARN, arn.String()),
+		resource.EnvVarFromSecret(common.EnvAccessKeyID,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-		resource.EnvVarFromSecret(envSecretAccessKey,
+		resource.EnvVarFromSecret(common.EnvSecretAccessKey,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
 	)

--- a/pkg/reconciler/awssnssource/reconciler.go
+++ b/pkg/reconciler/awssnssource/reconciler.go
@@ -21,14 +21,19 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	corev1 "k8s.io/api/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
+	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/object"
 )
 
@@ -57,15 +62,22 @@ var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AWSSNSSource) reconciler.Event {
+	o.Status.InitializeConditions()
+	o.Status.ObservedGeneration = o.Generation
+
+	arn, err := arn.Parse(o.Spec.ARN)
+	if err != nil {
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning,
+			common.ReasonInvalidSpec, "failed to parse ARN: %s", err))
+	}
+
+	o.Status.CloudEventAttributes = createCloudEventAttributes(arn)
+
 	// inject object into context for usage in event recorder and
 	// reconciliation logic
 	ctx = object.With(ctx, o)
 
-	o.Status.InitializeConditions()
-	o.Status.ObservedGeneration = o.Generation
-	o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
-
-	return r.reconcileAdapter(ctx)
+	return r.reconcileAdapter(ctx, arn)
 }
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called

--- a/pkg/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/reconciler/awssnssource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/sns"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,11 +57,10 @@ const (
 
 	tImg = "registry/image:tag"
 
-	tTopic  = "triggermeshtest"
-	tRegion = "us-test-0"
-
 	tMetricsDomain = "testing"
 )
+
+var tARN = NewARN(sns.ServiceName, "triggermeshtest")
 
 var tSinkURI = &apis.URL{
 	Scheme: "http",
@@ -288,8 +289,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSSNSSource {
 			UID:       tUID,
 		},
 		Spec: v1alpha1.AWSSNSSourceSpec{
-			Topic:  tTopic,
-			Region: tRegion,
+			ARN: tARN.String(),
 			Credentials: v1alpha1.AWSSecurityCredentials{
 				AccessKeyID: v1alpha1.ValueFromField{
 					ValueFromSecret: tAccessKeyIDSelector,
@@ -311,7 +311,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSSNSSource {
 	}
 
 	if len(skipCEAtrributes) == 0 {
-		o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
+		o.Status.CloudEventAttributes = createCloudEventAttributes(tARN)
 	}
 
 	o.Status.InitializeConditions()
@@ -414,36 +414,33 @@ func newAdapterDeployment() *appsv1.Deployment {
 						Image: tImg,
 						Env: []corev1.EnvVar{
 							{
-								Name:  common.NameEnvVar,
+								Name:  common.EnvName,
 								Value: tName,
 							}, {
-								Name:  common.NamespaceEnvVar,
+								Name:  common.EnvNamespace,
 								Value: tNs,
 							}, {
-								Name:  common.SinkEnvVar,
+								Name:  common.EnvSink,
 								Value: tSinkURI.String(),
 							}, {
-								Name:  common.LoggingConfigEnvVar,
+								Name:  common.EnvLoggingConfig,
 								Value: `{"zap-logger-config":"{\"level\": \"info\"}"}`,
 							}, {
-								Name: common.MetricsConfigEnvVar,
+								Name: common.EnvMetricsConfig,
 								Value: `{"Domain":"` + tMetricsDomain + `",` +
 									`"Component":"` + adapterName + `",` +
 									`"PrometheusPort":0,` +
 									`"ConfigMap":{"metrics.backend":"prometheus"}}`,
 							}, {
-								Name:  envTopic,
-								Value: tTopic,
+								Name:  common.EnvARN,
+								Value: tARN.String(),
 							}, {
-								Name:  envRegion,
-								Value: tRegion,
-							}, {
-								Name: envAccessKeyID,
+								Name: common.EnvAccessKeyID,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tAccessKeyIDSelector,
 								},
 							}, {
-								Name: envSecretAccessKey,
+								Name: common.EnvSecretAccessKey,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tSecretAccessKeySelector,
 								},

--- a/pkg/reconciler/awssnssource/status.go
+++ b/pkg/reconciler/awssnssource/status.go
@@ -17,17 +17,19 @@ limitations under the License.
 package awssnssource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSSNSSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
-			Type:   v1alpha1.AWSSNSEventType(v1alpha1.AWSKinesisGenericEventType),
-			Source: v1alpha1.AWSSNSEventSource(srcSpec.Region, srcSpec.Topic),
+			Type:   v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSSNSGenericEventType),
+			Source: arn.String(),
 		},
 	}
 }

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,13 +42,6 @@ import (
 
 const adapterName = "awssqssource"
 
-const (
-	envQueue           = "QUEUE"
-	envRegion          = "AWS_REGION"
-	envAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
-
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -59,7 +54,7 @@ type adapterConfig struct {
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
+func (r *Reconciler) reconcileAdapter(ctx context.Context, arn arn.ARN) error {
 	o := object.FromContext(ctx).(*v1alpha1.AWSSQSSource)
 
 	sinkRef := &o.Spec.Sink.Ref
@@ -76,7 +71,7 @@ func (r *Reconciler) reconcileAdapter(ctx context.Context) error {
 	}
 	o.Status.MarkSink(sinkURI)
 
-	desiredAdapter := makeAdapterDeployment(ctx, sinkURI, r.adapterCfg)
+	desiredAdapter := makeAdapterDeployment(ctx, arn, sinkURI, r.adapterCfg)
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -142,7 +137,9 @@ func (r *Reconciler) syncAdapterDeployment(ctx context.Context,
 }
 
 // makeAdapterDeployment returns a Deployment object for the source's adapter.
-func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+func makeAdapterDeployment(ctx context.Context, arn arn.ARN,
+	sinkURI *apis.URL, adapterCfg *adapterConfig) *appsv1.Deployment {
+
 	o := object.FromContext(ctx).(*v1alpha1.AWSSQSSource)
 	name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), o.Name)
 
@@ -168,17 +165,16 @@ func makeAdapterDeployment(ctx context.Context, sinkURI *apis.URL, adapterCfg *a
 
 		resource.Image(adapterCfg.Image),
 
-		resource.EnvVar(common.NameEnvVar, o.Name),
-		resource.EnvVar(common.NamespaceEnvVar, o.Namespace),
-		resource.EnvVar(common.SinkEnvVar, sinkURIStr),
-		resource.EnvVar(common.LoggingConfigEnvVar, adapterCfg.LoggingCfg),
-		resource.EnvVar(common.MetricsConfigEnvVar, adapterCfg.MetricsCfg),
-		resource.EnvVar(envQueue, o.Spec.Queue),
-		resource.EnvVar(envRegion, o.Spec.Region),
-		resource.EnvVarFromSecret(envAccessKeyID,
+		resource.EnvVar(common.EnvName, o.Name),
+		resource.EnvVar(common.EnvNamespace, o.Namespace),
+		resource.EnvVar(common.EnvSink, sinkURIStr),
+		resource.EnvVar(common.EnvLoggingConfig, adapterCfg.LoggingCfg),
+		resource.EnvVar(common.EnvMetricsConfig, adapterCfg.MetricsCfg),
+		resource.EnvVar(common.EnvARN, arn.String()),
+		resource.EnvVarFromSecret(common.EnvAccessKeyID,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
 			o.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-		resource.EnvVarFromSecret(envSecretAccessKey,
+		resource.EnvVarFromSecret(common.EnvSecretAccessKey,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
 			o.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
 	)

--- a/pkg/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/reconciler/awssqssource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/sqs"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,11 +57,10 @@ const (
 
 	tImg = "registry/image:tag"
 
-	tQueue  = "triggermeshtest"
-	tRegion = "us-test-0"
-
 	tMetricsDomain = "testing"
 )
+
+var tARN = NewARN(sqs.ServiceName, "triggermeshtest")
 
 var tSinkURI = &apis.URL{
 	Scheme: "http",
@@ -288,8 +289,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSSQSSource {
 			UID:       tUID,
 		},
 		Spec: v1alpha1.AWSSQSSourceSpec{
-			Queue:  tQueue,
-			Region: tRegion,
+			ARN: tARN.String(),
 			Credentials: v1alpha1.AWSSecurityCredentials{
 				AccessKeyID: v1alpha1.ValueFromField{
 					ValueFromSecret: tAccessKeyIDSelector,
@@ -311,7 +311,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSSQSSource {
 	}
 
 	if len(skipCEAtrributes) == 0 {
-		o.Status.CloudEventAttributes = createCloudEventAttributes(&o.Spec)
+		o.Status.CloudEventAttributes = createCloudEventAttributes(tARN)
 	}
 
 	o.Status.InitializeConditions()
@@ -414,36 +414,33 @@ func newAdapterDeployment() *appsv1.Deployment {
 						Image: tImg,
 						Env: []corev1.EnvVar{
 							{
-								Name:  common.NameEnvVar,
+								Name:  common.EnvName,
 								Value: tName,
 							}, {
-								Name:  common.NamespaceEnvVar,
+								Name:  common.EnvNamespace,
 								Value: tNs,
 							}, {
-								Name:  common.SinkEnvVar,
+								Name:  common.EnvSink,
 								Value: tSinkURI.String(),
 							}, {
-								Name:  common.LoggingConfigEnvVar,
+								Name:  common.EnvLoggingConfig,
 								Value: `{"zap-logger-config":"{\"level\": \"info\"}"}`,
 							}, {
-								Name: common.MetricsConfigEnvVar,
+								Name: common.EnvMetricsConfig,
 								Value: `{"Domain":"` + tMetricsDomain + `",` +
 									`"Component":"` + adapterName + `",` +
 									`"PrometheusPort":0,` +
 									`"ConfigMap":{"metrics.backend":"prometheus"}}`,
 							}, {
-								Name:  envQueue,
-								Value: tQueue,
+								Name:  common.EnvARN,
+								Value: tARN.String(),
 							}, {
-								Name:  envRegion,
-								Value: tRegion,
-							}, {
-								Name: envAccessKeyID,
+								Name: common.EnvAccessKeyID,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tAccessKeyIDSelector,
 								},
 							}, {
-								Name: envSecretAccessKey,
+								Name: common.EnvSecretAccessKey,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: tSecretAccessKeySelector,
 								},

--- a/pkg/reconciler/awssqssource/status.go
+++ b/pkg/reconciler/awssqssource/status.go
@@ -17,17 +17,19 @@ limitations under the License.
 package awssqssource
 
 import (
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // createCloudEventAttributes returns the CloudEvent types supported by the
 // source.
-func createCloudEventAttributes(srcSpec *v1alpha1.AWSSQSSourceSpec) []duckv1.CloudEventAttributes {
+func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
 	return []duckv1.CloudEventAttributes{
 		{
-			Type:   v1alpha1.AWSSQSEventType(v1alpha1.AWSSQSGenericEventType),
-			Source: v1alpha1.AWSSQSEventSource(srcSpec.Region, srcSpec.Queue),
+			Type:   v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSSQSGenericEventType),
+			Source: arn.String(),
 		},
 	}
 }

--- a/pkg/reconciler/common/env.go
+++ b/pkg/reconciler/common/env.go
@@ -18,9 +18,13 @@ package common
 
 // Common environment variables propagated to adapters.
 const (
-	NameEnvVar          = "NAME"
-	NamespaceEnvVar     = "NAMESPACE"
-	SinkEnvVar          = "K_SINK"
-	LoggingConfigEnvVar = "K_LOGGING_CONFIG"
-	MetricsConfigEnvVar = "K_METRICS_CONFIG"
+	EnvName          = "NAME"
+	EnvNamespace     = "NAMESPACE"
+	EnvSink          = "K_SINK"
+	EnvLoggingConfig = "K_LOGGING_CONFIG"
+	EnvMetricsConfig = "K_METRICS_CONFIG"
+
+	EnvARN             = "ARN"
+	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
+	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
 )

--- a/pkg/reconciler/common/events.go
+++ b/pkg/reconciler/common/events.go
@@ -29,4 +29,7 @@ const (
 
 	// ReasonBadSinkURI indicates that the URI of a sink can't be determined.
 	ReasonBadSinkURI = "BadSinkURI"
+
+	// ReasonInvalidSpec indicates that spec of a reconciled object is invalid.
+	ReasonInvalidSpec = "InvalidSpec"
 )

--- a/pkg/reconciler/common/semantic/semantic_test.go
+++ b/pkg/reconciler/common/semantic/semantic_test.go
@@ -91,9 +91,10 @@ func TestDeploymentEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		//nolint:scopelint
 		t.Run(name, func(t *testing.T) {
-			desired := tc.prep() //nolint:scopelint
-			switch tc.expect {   //nolint:scopelint
+			desired := tc.prep()
+			switch tc.expect {
 			case true:
 				assert.True(t, deploymentEqual(desired, current))
 			case false:

--- a/pkg/reconciler/testing/aws.go
+++ b/pkg/reconciler/testing/aws.go
@@ -14,22 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package awsiotsource
+package testing
 
-import (
-	"github.com/aws/aws-sdk-go/aws/arn"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
+import "github.com/aws/aws-sdk-go/aws/arn"
 
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
-)
-
-// createCloudEventAttributes returns the CloudEvent types supported by the
-// source.
-func createCloudEventAttributes(arn arn.ARN) []duckv1.CloudEventAttributes {
-	return []duckv1.CloudEventAttributes{
-		{
-			Type:   v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSIoTGenericEventType),
-			Source: arn.String(),
-		},
+// NewARN returns a ARN with the given attributes.
+func NewARN(service, resource string) arn.ARN {
+	return arn.ARN{
+		Partition: "aws",
+		Service:   service,
+		Region:    "us-test-0",
+		AccountID: "1234567890",
+		Resource:  resource,
 	}
 }

--- a/pkg/reconciler/testing/controller.go
+++ b/pkg/reconciler/testing/controller.go
@@ -92,16 +92,17 @@ func TestControllerConstructorFailures(t *testing.T, ctor injection.ControllerCo
 	}
 
 	for n, tc := range testCases {
+		//nolint:scopelint
 		t.Run(n, func(t *testing.T) {
 			ctx, _ := rt.SetupFakeContext(t)
 			cmw := &configmap.StaticWatcher{}
 
-			undo := tc.initFn(&cmw) //nolint:scopelint
+			undo := tc.initFn(&cmw)
 			if undo != nil {
 				defer undo()
 			}
 
-			tc.assertFn(t, func() { //nolint:scopelint
+			tc.assertFn(t, func() {
 				_ = ctor(ctx, cmw)
 			})
 		})


### PR DESCRIPTION
ARN is the one standard way to identify a resource across the AWS landscape. First, a ARN contains all the information needed by controllers and adapters to operate on a resource. Second (and even more importantly), it allows us to associate event types to a unique `source` in the event registry.

Notice that our event types refer now to a uniquely identifiable source ARN:
```console
$ kubectl -n dev get eventtypes.eventing.knative.dev
NAME                               TYPE                                       SOURCE                                                                         SCHEMA   BROKER    DESCRIPTION   READY   REASON
599a73bf8d12f3555176d3eaddd77814   com.amazon.codecommit.push                 arn:aws:codecommit:us-west-2:123456789012:triggermeshtest                               default                 True
5e4995d0cb939918b826819adced4e17   com.amazon.dynamodb.insert                 arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest                           default                 True
a27c71dc9ad0202d0ba48575122ce104   com.amazon.cognito-identity.sync_trigger   arn:aws:cognito-identity:us-west-2:123456789012:identitypool/triggermeshtest            default                 True
a566ced1a09f73fb8d3cb2cc12cb35ab   com.amazon.kinesis.stream_record           arn:aws:kinesis:us-west-2:123456789012:stream/triggermeshtest                           default                 True
abf4910f7c204fae93bae92c42c248ea   com.amazon.dynamodb.remove                 arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest                           default                 True
aebe893c1e3e43e932b8a514465376be   com.amazon.codecommit.pull_request         arn:aws:codecommit:us-west-2:123456789012:triggermeshtest                               default                 True
bd06f99e869b71599c88d25fa2dcac75   com.amazon.sqs.message                     arn:aws:sqs:us-west-2:123456789012:triggermeshtest                                      default                 True
cf9b00c73423d85dd617918c742023be   com.amazon.dynamodb.modify                 arn:aws:dynamodb:us-west-2:123456789012:table/triggermeshtest                           default                 True
e0fcc4ad1646fc398278a4b04e2855ec   com.amazon.sns.notification                arn:aws:sns:us-west-2:123456789012:triggermeshtest                                      default                 True 
```

Closes #106