### PR TITLE
Minor DynamoDB fixes

### DIFF
--- a/pkg/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/adapter/awsdynamodbsource/adapter.go
@@ -262,6 +262,7 @@ func asEventSubject(record *dynamodbstreams.Record) string {
 
 	subject := strBuilderPool.Get().(*strings.Builder)
 	defer strBuilderPool.Put(subject)
+	defer subject.Reset()
 
 	i := 0
 	for k := range record.Dynamodb.Keys {

--- a/pkg/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/adapter/awsdynamodbsource/adapter.go
@@ -89,7 +89,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(stopCh <-chan struct{}) error {
-	a.logger.Infof("Listening to AWS DynamoDB streams for table: %s", a.table)
+	a.logger.Info("Listening to AWS DynamoDB streams for table: " + a.table)
 
 	streams, err := a.getStreams()
 	if err != nil {
@@ -227,7 +227,7 @@ func (a *adapter) processLatestRecords(shardIterator *string) error {
 }
 
 func (a *adapter) sendDynamoDBEvent(record *dynamodbstreams.Record) error {
-	a.logger.Infof("Processing record ID: %s", &record.EventID)
+	a.logger.Info("Processing record ID: " + *record.EventID)
 
 	data := &DynamoDBEvent{
 		AwsRegion:    record.AwsRegion,

--- a/pkg/adapter/awsdynamodbsource/adapter_test.go
+++ b/pkg/adapter/awsdynamodbsource/adapter_test.go
@@ -215,5 +215,6 @@ func TestSendCloudevent(t *testing.T) {
 	gotData := string(gotEvents[0].Data())
 	assert.EqualValues(t, wantData, gotData, "Expected event %q, got %q", wantData, gotData)
 
-	assert.Equal(t, "key1,key2", gotEvents[0].Subject())
+	assert.Contains(t, []string{"key1,key2", "key2,key1"}, gotEvents[0].Subject(),
+		`Subject contains keys "key1,key2" in any order`)
 }


### PR DESCRIPTION
1. unit test: Ignore keys order in event subject.

    These are generated by iterating over a `map`, meaning their order is unpredictable. Sorting could also solve it, but it's another computation which we don't need here.

1. Reset buffers before returning them to pool.

    I noticed event subjects were sometimes `key1,key2`, sometimes `key1,key2key1,key2`, sometimes `key1,key2key1,key2key1,key2`, ... because buffers are never reset before being returned to the pool.

1. Prefer `log.Info` to `log.Infof` when string parsing isn't required.