### PR TITLE
AWS CodeCommit source - avoid "for" loops

### DIFF
--- a/pkg/adapter/awscodecommitsource/adapter_test.go
+++ b/pkg/adapter/awscodecommitsource/adapter_test.go
@@ -73,7 +73,7 @@ func TestSendPREvent(t *testing.T) {
 	pr := &codecommit.PullRequest{}
 	pr.SetPullRequestId("12345")
 
-	err := a.sendPREvent(pr)
+	err := a.sendEvent(pr)
 	assert.NoError(t, err)
 
 	gotEvents := ceClient.Sent()
@@ -96,7 +96,7 @@ func TestSendPushEvent(t *testing.T) {
 	commit := &codecommit.Commit{}
 	commit.SetCommitId("12345")
 
-	err := a.sendPushEvent(commit)
+	err := a.sendEvent(commit)
 	assert.NoError(t, err)
 
 	gotEvents := ceClient.Sent()


### PR DESCRIPTION
- `preparePullRequests` doesn't have `for` loop anymore:
  it's not explicitly documented, but it looks like `nextToken` in response is set only when we either specify list limit or there are more then 1000 items in list. However, our current loop break [condition](https://github.com/triggermesh/aws-event-sources/blob/b39f3d67459a8b0e6fdae3f5e5d773211df0ba47/pkg/adapter/awscodecommitsource/adapter.go#L241) doesn't seem to do a [correct](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/go/example_code/cloudwatch/CloudWatchGetLogEvents.go#L66) check anyway and we're not hanging there forever only because `nextToken` is not used.
- `sendPushEvent` and `sendPREvent` functions merged into a single `sendEvent` with event type assertion

_mentioned in #58_ 