### PR TITLE
ci: remove dry-run flag from gsutil rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
             helm repo index --merge upstream.yaml --url https://storage.googleapis.com/${GOOGLE_PROJECT_ID}-charts repo/
       - run:
           name: Publishing charts
-          command: gsutil rsync -r -n repo/  gs://${GOOGLE_PROJECT_ID}-charts/
+          command: gsutil rsync -r repo/  gs://${GOOGLE_PROJECT_ID}-charts/
 
   release:
     executor:


### PR DESCRIPTION
removes accidentally committed dry-run flag from chart repo sync