### PR TITLE
ci: publish chart branch activity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ workflows:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
-              ignore: /.*/
+              only: master
       - deploy:
           name: update-staging-config
           cluster: staging


### PR DESCRIPTION
This change will package and publish the chart whenever there are changes to it.
As a rule of thumb the chart version should be updated in each PR that makes changes to the chart