### PR TITLE
Find adapter by label and owner

### DIFF
--- a/pkg/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/reconciler/awscodecommitsource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package awscodecommitsource
 
 import (
-	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,8 +29,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awscodecommitsource"
 
 const (
 	envBranch     = "BRANCH"
@@ -50,8 +47,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSCodeCommitSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awscodecommitsource/controller.go
+++ b/pkg/reconciler/awscodecommitsource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSCodeCommitSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSCodeCommitSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/reconciler/awscognitoidentitysource/adapter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package awscognitoidentitysource
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +27,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awscognitoidentitysource"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -44,8 +40,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoIdentitySource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awscognitoidentitysource/controller.go
+++ b/pkg/reconciler/awscognitoidentitysource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSCognitoIdentitySource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSCognitoIdentitySource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/reconciler/awscognitouserpoolsource/adapter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package awscognitouserpoolsource
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +27,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awscognitouserpoolsource"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -44,8 +40,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoUserPoolSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awscognitouserpoolsource/controller.go
+++ b/pkg/reconciler/awscognitouserpoolsource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSCognitoUserPoolSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSCognitoUserPoolSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/reconciler/awsdynamodbsource/adapter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package awsdynamodbsource
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +27,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awsdynamodbsource"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -44,8 +40,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSDynamoDBSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/reconciler/awsdynamodbsource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSDynamoDBSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSDynamoDBSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awsiotsource/adapter.go
+++ b/pkg/reconciler/awsiotsource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package awsiotsource
 
 import (
-	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,8 +29,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awsiotsource"
 
 const (
 	envEndpoint        = "THING_SHADOW_ENDPOINT"
@@ -56,8 +53,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSIoTSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awsiotsource/controller.go
+++ b/pkg/reconciler/awsiotsource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSIoTSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSIoTSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awskinesissource/adapter.go
+++ b/pkg/reconciler/awskinesissource/adapter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package awskinesissource
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +27,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awskinesissource"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -44,8 +40,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSKinesisSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awskinesissource/controller.go
+++ b/pkg/reconciler/awskinesissource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSKinesisSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSKinesisSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awssnssource/adapter.go
+++ b/pkg/reconciler/awssnssource/adapter.go
@@ -31,8 +31,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
 
-const adapterName = "awssnssource"
-
 const (
 	envSubscriptionAttrs = "SUBSCRIPTION_ATTRIBUTES"
 	envPublicURL         = "PUBLIC_URL"
@@ -58,8 +56,10 @@ type adapterConfig struct {
 // adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
 // given source object and adapter config.
 func adapterServiceBuilder(src *v1alpha1.AWSSNSSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *servingv1.Service {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awssnssource/controller.go
+++ b/pkg/reconciler/awssnssource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSSNSSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericServiceReconciler(
 		ctx,
-		(&v1alpha1.AWSSNSSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package awssqssource
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +27,6 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "awssqssource"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -44,8 +40,10 @@ type adapterConfig struct {
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/awssqssource/controller.go
+++ b/pkg/reconciler/awssqssource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.AWSSQSSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericDeploymentReconciler(
 		ctx,
-		(&v1alpha1.AWSSQSSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"strings"
+
+	"knative.dev/pkg/kmeta"
+)
+
+// AdapterName returns the adapter's name for the given source object.
+func AdapterName(o kmeta.OwnerRefable) string {
+	return strings.ToLower(o.GetGroupVersionKind().Kind)
+}


### PR DESCRIPTION
Implements a method that finds the receive adapter for a given source by label and owner, instead of making assumptions on the adapter's name.

Relates to triggermesh/knative-sources#59