### PR TITLE
Safely generate env vars for AWS security crendentials

### DIFF
--- a/pkg/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/reconciler/awscodecommitsource/adapter.go
@@ -80,12 +80,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSCodeCommitSource, cfg *adapterCon
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
 			resource.EnvVar(envBranch, src.Spec.Branch),
 			resource.EnvVar(envEventTypes, strings.Join(src.Spec.EventTypes, ",")),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/reconciler/awscognitoidentitysource/adapter.go
@@ -71,12 +71,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoIdentitySource, cfg *adapt
 			resource.EnvVar(common.EnvNamespace, src.Namespace),
 			resource.EnvVar(common.EnvSink, sinkURIStr),
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/reconciler/awscognitouserpoolsource/adapter.go
@@ -71,12 +71,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoUserPoolSource, cfg *adapt
 			resource.EnvVar(common.EnvNamespace, src.Namespace),
 			resource.EnvVar(common.EnvSink, sinkURIStr),
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/reconciler/awsdynamodbsource/adapter.go
@@ -71,12 +71,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSDynamoDBSource, cfg *adapterConfi
 			resource.EnvVar(common.EnvNamespace, src.Namespace),
 			resource.EnvVar(common.EnvSink, sinkURIStr),
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awskinesissource/adapter.go
+++ b/pkg/reconciler/awskinesissource/adapter.go
@@ -71,12 +71,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSKinesisSource, cfg *adapterConfig
 			resource.EnvVar(common.EnvNamespace, src.Namespace),
 			resource.EnvVar(common.EnvSink, sinkURIStr),
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awssnssource/adapter.go
+++ b/pkg/reconciler/awssnssource/adapter.go
@@ -100,12 +100,7 @@ func adapterServiceBuilder(src *v1alpha1.AWSSNSSource, cfg *adapterConfig) commo
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
 			resource.EnvVar(envSubscriptionAttrs, subsAttrsStr),
 			resource.EnvVar(envPublicURL, adapterURL),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVar(common.EnvMetricsPrometheusPort, strconv.Itoa(int(metricsPrometheusPort))),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -71,12 +71,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 			resource.EnvVar(common.EnvNamespace, src.Namespace),
 			resource.EnvVar(common.EnvSink, sinkURIStr),
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVarFromSecret(common.EnvAccessKeyID,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Name,
-				src.Spec.Credentials.AccessKeyID.ValueFromSecret.Key),
-			resource.EnvVarFromSecret(common.EnvSecretAccessKey,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Name,
-				src.Spec.Credentials.SecretAccessKey.ValueFromSecret.Key),
+			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -19,10 +19,54 @@ package common
 import (
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/kmeta"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
 // AdapterName returns the adapter's name for the given source object.
 func AdapterName(o kmeta.OwnerRefable) string {
 	return strings.ToLower(o.GetGroupVersionKind().Kind)
+}
+
+// MakeSecurityCredentialsEnvVars returns environment variables for the given
+// AWS security credentials.
+func MakeSecurityCredentialsEnvVars(creds v1alpha1.AWSSecurityCredentials) []corev1.EnvVar {
+	const (
+		envAccessKeyID = iota
+		envSecretAccessKey
+	)
+
+	credsEnvVars := []corev1.EnvVar{
+		{Name: EnvAccessKeyID},
+		{Name: EnvSecretAccessKey},
+	}
+
+	if vfs := creds.AccessKeyID.ValueFromSecret; vfs != nil {
+		credsEnvVars[envAccessKeyID].ValueFrom = envVarValueFromSecret(vfs.Name, vfs.Key)
+	} else {
+		credsEnvVars[envAccessKeyID].Value = creds.AccessKeyID.Value
+	}
+
+	if vfs := creds.SecretAccessKey.ValueFromSecret; vfs != nil {
+		credsEnvVars[envSecretAccessKey].ValueFrom = envVarValueFromSecret(vfs.Name, vfs.Key)
+	} else {
+		credsEnvVars[envSecretAccessKey].Value = creds.SecretAccessKey.Value
+	}
+
+	return credsEnvVars
+}
+
+// envVarValueFromSecret returns the value of an environment variable sourced
+// from a Kubernetes Secret.
+func envVarValueFromSecret(secretName, secretKey string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: secretName,
+			},
+			Key: secretKey,
+		},
+	}
 }


### PR DESCRIPTION
Instead of assuming both the key ID and secret access key always come from a `Secret` reference, call the `MakeSecurityCredentialsEnvVars()` helper which supports both `Value` and `ValueFromSecret`.