### PR TITLE
Restrict patch to resources that implement Finalizer

### DIFF
--- a/aws-event-sources-operator/helm-charts/aws-event-sources/templates/clusterroles.yaml
+++ b/aws-event-sources-operator/helm-charts/aws-event-sources/templates/clusterroles.yaml
@@ -65,7 +65,6 @@ rules:
   - list
   - watch
   - get
-  - patch
 - apiGroups:
   - sources.triggermesh.io
   resources:
@@ -92,6 +91,14 @@ rules:
   - awssqssources/finalizers
   verbs:
   - update
+
+# Set finalizers
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awssnssources
+  verbs:
+  - patch
 
 # Read controller configurations
 - apiGroups:

--- a/chart/templates/clusterroles.yaml
+++ b/chart/templates/clusterroles.yaml
@@ -65,7 +65,6 @@ rules:
   - list
   - watch
   - get
-  - patch
 - apiGroups:
   - sources.triggermesh.io
   resources:
@@ -92,6 +91,14 @@ rules:
   - awssqssources/finalizers
   verbs:
   - update
+
+# Set finalizers
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awssnssources
+  verbs:
+  - patch
 
 # Read controller configurations
 - apiGroups:

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -63,7 +63,6 @@ rules:
   - list
   - watch
   - get
-  - patch
 - apiGroups:
   - sources.triggermesh.io
   resources:
@@ -77,6 +76,14 @@ rules:
   - awssqssources/status
   verbs:
   - update
+
+# Set finalizers
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awssnssources
+  verbs:
+  - patch
 
 # Read controller configurations
 - apiGroups:


### PR DESCRIPTION
`patch` is not required in the ClusterRole, except for resources that implement a finalizer.

Here's where the code checks whether a type implements a finalizer:

https://github.com/triggermesh/aws-event-sources/blob/ba2dd9983d11956c60129e163b1acbe8ed3f2354/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscodecommitsource/reconciler.go#L401-L403