### PR TITLE
cloudbuild: add (new) kaniko flags to speed up cloudbuilds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - gcp-cli/initialize
       - run:
           name: Building docker image
-          command: make -j4 cloudbuild-test
+          command: make -j6 cloudbuild-test
 
   test:
     executor:
@@ -71,7 +71,7 @@ jobs:
       - gcp-cli/initialize
       - run:
           name: Publishing docker image
-          command: IMAGE_SHA=${CIRCLE_SHA1} IMAGE_TAG=${CIRCLE_TAG:-latest} make -j4 cloudbuild
+          command: IMAGE_SHA=${CIRCLE_SHA1} IMAGE_TAG=${CIRCLE_TAG:-latest} make -j6 cloudbuild
 
   deploy:
     description: Patches target cluster configuration

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,8 @@ steps:
   - --cache-repo=gcr.io/$PROJECT_ID/${_CMD}/cache
   - --cache=${_KANIKO_USE_BUILD_CACHE}
   - --no-push=${_KANIKO_NO_PUSH}
+  - --snapshotMode=redo
+  - --use-new-run
   - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 


### PR DESCRIPTION
The latest kaniko release has two new flags that boasts of upto 75% performance optimization