### PR TITLE
Receive and delete SQS messages in batches

### DIFF
--- a/pkg/adapter/awssqssource/adapter_test.go
+++ b/pkg/adapter/awssqssource/adapter_test.go
@@ -18,9 +18,13 @@ package awssqssource
 
 import (
 	"errors"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -32,61 +36,68 @@ import (
 
 type mockedReceiveMsgs struct {
 	sqsiface.SQSAPI
-	Resp sqs.ReceiveMessageOutput
+	resp *sqs.ReceiveMessageOutput
 	err  error
 }
 
 type mockedDeleteMsgs struct {
 	sqsiface.SQSAPI
-	Resp sqs.DeleteMessageOutput
+	resp *sqs.DeleteMessageBatchOutput
 	err  error
 }
 
 type mockedGetQueueURL struct {
 	sqsiface.SQSAPI
-	Resp sqs.GetQueueUrlOutput
+	resp *sqs.GetQueueUrlOutput
 	err  error
 }
 
 func (m mockedReceiveMsgs) ReceiveMessage(in *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
-	return &m.Resp, m.err
+	return m.resp, m.err
 }
 
-func (m mockedDeleteMsgs) DeleteMessage(in *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
-	return &m.Resp, m.err
+func (m mockedDeleteMsgs) DeleteMessageBatch(in *sqs.DeleteMessageBatchInput) (*sqs.DeleteMessageBatchOutput, error) {
+	return m.resp, m.err
 }
 
 func (m mockedGetQueueURL) GetQueueUrl(*sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) { //nolint:golint,stylecheck
-	return &m.Resp, m.err
+	return m.resp, m.err
 }
 
 func TestQueueLookup(t *testing.T) {
 	cases := []struct {
-		Resp     sqs.GetQueueUrlOutput
+		resp     *sqs.GetQueueUrlOutput
 		err      error
-		Expected *string
+		expected *string
 	}{
 		{ // Case 1, expect parsed responses
-			Resp:     sqs.GetQueueUrlOutput{QueueUrl: aws.String("testQueueURL")},
+			resp: &sqs.GetQueueUrlOutput{
+				QueueUrl: aws.String("testQueueURL"),
+			},
 			err:      nil,
-			Expected: aws.String("testQueueURL"),
+			expected: aws.String("testQueueURL"),
 		},
 		{ // Case 2, expect error
-			Resp:     sqs.GetQueueUrlOutput{QueueUrl: aws.String("")},
+			resp: &sqs.GetQueueUrlOutput{
+				QueueUrl: aws.String(""),
+			},
 			err:      errors.New("fake getQueueUrl error"),
-			Expected: aws.String(""),
+			expected: aws.String(""),
 		},
 	}
 
 	for _, c := range cases {
 		a := &adapter{
-			logger:    loggingtesting.TestLogger(t),
-			sqsClient: mockedGetQueueURL{Resp: c.Resp, err: c.err},
+			logger: loggingtesting.TestLogger(t),
+			sqsClient: mockedGetQueueURL{
+				resp: c.resp,
+				err:  c.err,
+			},
 		}
 
-		url, err := a.queueLookup("testQueue")
+		url, err := a.queueLookup("")
 		assert.Equal(t, c.err, err)
-		assert.Equal(t, c.Expected, url.QueueUrl)
+		assert.Equal(t, c.expected, url.QueueUrl)
 	}
 }
 
@@ -94,47 +105,49 @@ func TestGetMessages(t *testing.T) {
 	const queueURL = "mockURL"
 
 	cases := []struct {
-		Resp     sqs.ReceiveMessageOutput
+		resp     *sqs.ReceiveMessageOutput
 		err      error
-		Expected []sqs.Message
+		expected []*sqs.Message
 	}{
 		{ // Case 1, expect parsed responses
-			Resp: sqs.ReceiveMessageOutput{
-				Messages: []*sqs.Message{
-					{},
-				},
+			resp: &sqs.ReceiveMessageOutput{
+				Messages: make([]*sqs.Message, 2),
 			},
-			err: nil,
-			Expected: []sqs.Message{
-				{},
-			},
+			err:      nil,
+			expected: make([]*sqs.Message, 2),
 		},
-		{ // Case 2, not messages returned
-			Resp:     sqs.ReceiveMessageOutput{},
+		{ // Case 2, no message returned
+			resp:     &sqs.ReceiveMessageOutput{},
 			err:      errors.New("no message found"),
-			Expected: []sqs.Message{},
+			expected: []*sqs.Message{},
 		},
 	}
 
 	for _, c := range cases {
 		a := &adapter{
-			logger:    loggingtesting.TestLogger(t),
-			sqsClient: mockedReceiveMsgs{Resp: c.Resp, err: c.err},
+			logger: loggingtesting.TestLogger(t),
+			sqsClient: mockedReceiveMsgs{
+				resp: c.resp,
+				err:  c.err},
 		}
 
 		msgs, err := a.getMessages(queueURL)
 		assert.Equal(t, c.err, err)
-		assert.Equal(t, len(c.Expected), len(msgs))
+		assert.Equal(t, len(c.expected), len(msgs))
 	}
 }
 
-func TestPushMessage(t *testing.T) {
-	msg := sqs.Message{
-		MessageId: aws.String("foo"),
-		Body:      aws.String("bar"),
-		Attributes: map[string]*string{
-			"SentTimestamp": aws.String("1549540781"),
-		}}
+func TestSendEvents(t *testing.T) {
+	msgs := []*sqs.Message{
+		{
+			MessageId: aws.String("0001"),
+			Body:      aws.String("msg1"),
+		},
+		{
+			MessageId: aws.String("0002"),
+			Body:      aws.String("msg2"),
+		},
+	}
 
 	ceClient := adaptertest.NewTestClient()
 
@@ -143,23 +156,40 @@ func TestPushMessage(t *testing.T) {
 		ceClient: ceClient,
 	}
 
-	err := a.sendSQSEvent(&msg)
+	sent, err := a.sendSQSEvents(msgs)
+	ceClientSentEvents := ceClient.Sent()
 	assert.NoError(t, err)
+	assert.Len(t, sent, len(msgs), "The function didn't return the expected number of messages")
+	require.Len(t, ceClientSentEvents, len(msgs), "The client didn't send the expected number of messages")
 
-	gotEvents := ceClient.Sent()
-	assert.Len(t, gotEvents, 1, "Expected 1 event, got %d", len(gotEvents))
+	sort.Sort(eventsByID(ceClientSentEvents))
 
-	var gotData sqs.Message
-	err = gotEvents[0].DataAs(&gotData)
-	assert.NoError(t, err)
-	assert.EqualValues(t, msg, gotData, "Expected event %q, got %q", msg, gotData)
+	for i, e := range ceClientSentEvents {
+		sentMsg := &sqs.Message{}
+		err := e.DataAs(sentMsg)
+		assert.NoError(t, err)
+		assert.EqualValues(t, msgs[i], sentMsg, "%d: sent payload differs from original message", i)
+	}
 }
+
+type eventsByID []cloudevents.Event
+
+func (ce eventsByID) Len() int           { return len(ce) }
+func (ce eventsByID) Less(i, j int) bool { return ce[i].ID() < ce[j].ID() }
+func (ce eventsByID) Swap(i, j int)      { ce[i], ce[j] = ce[j], ce[i] }
 
 func TestDeleteMessage(t *testing.T) {
 	const queueURL = "mockURL"
 
-	msg := sqs.Message{
-		ReceiptHandle: aws.String("foo"),
+	msgs := []*sqs.Message{
+		{
+			MessageId:     aws.String("0001"),
+			ReceiptHandle: aws.String("0001"),
+		},
+		{
+			MessageId:     aws.String("0002"),
+			ReceiptHandle: aws.String("0002"),
+		},
 	}
 
 	a := &adapter{
@@ -167,18 +197,55 @@ func TestDeleteMessage(t *testing.T) {
 	}
 
 	a.sqsClient = mockedDeleteMsgs{
-		Resp: sqs.DeleteMessageOutput{},
+		resp: &sqs.DeleteMessageBatchOutput{},
 		err:  nil,
 	}
 
-	err := a.deleteMessage(queueURL, msg.ReceiptHandle)
+	err := a.deleteMessages(queueURL, msgs)
 	assert.NoError(t, err)
 
 	a.sqsClient = mockedDeleteMsgs{
-		Resp: sqs.DeleteMessageOutput{},
+		resp: &sqs.DeleteMessageBatchOutput{},
 		err:  errors.New("fake deleteMessage error"),
 	}
 
-	err = a.deleteMessage(queueURL, msg.ReceiptHandle)
+	err = a.deleteMessages(queueURL, msgs)
 	assert.Error(t, err)
+}
+
+func TestErrList(t *testing.T) {
+	testCases := []struct {
+		name   string
+		errors []error
+		expect string
+	}{
+		{
+			name:   "no error",
+			errors: nil,
+			expect: "",
+		},
+		{
+			name: "one error",
+			errors: []error{
+				errors.New("err1"),
+			},
+			expect: "err1",
+		},
+		{
+			name: "multiple errors",
+			errors: []error{
+				errors.New("err1"),
+				errors.New("err2"),
+				errors.New("err3"),
+			},
+			expect: "[err1, err2, err3]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := &errList{errs: tc.errors}
+			assert.EqualError(t, errs, tc.expect)
+		})
+	}
 }


### PR DESCRIPTION
Process events in batches and increase the throughput from **~0.8 message/sec** to **~25 messagse/sec** (**~7.2 messages/sec** if we exclude the backoff  change in #214), considering a payload of 2 KiB.

We could improve this even more by also sending CloudEvents in batches, but neither the Go SDK not Knative dispatchers support that. As a workaround, I refactored the `sendSQSEvents` function to send each message in a separate goroutine.

There is still room for improvement, e.g. we could run multiple receiver goroutines and perform deletions in the background, but that's a topic for future experiments.