### PR TITLE
Replace pod/get with pod/list permission

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -158,7 +158,7 @@ rules:
   resources:
   - pods
   verbs:
-  - get
+  - list
 
 ---
 


### PR DESCRIPTION
Fixes #215

Here is the code that requires that permission:

https://github.com/triggermesh/aws-event-sources/blob/06803f2547ad66b5b617209955429fa12770f54c/pkg/status/status.go#L50-L52