### PR TITLE
DynamoDB: Process shards in parallel, recheck stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/aws/aws-sdk-go v1.31.12
+	github.com/aws/aws-sdk-go v1.35.28
 	github.com/cloudevents/sdk-go/v2 v2.2.0
 	github.com/google/go-cmp v0.5.2
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.31.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.31.12 h1:SxRRGyhlCagI0DYkhOg+FgdXGXzRTE3vEX/gsgFaiKQ=
 github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.35.28 h1:S2LuRnfC8X05zgZLC8gy/Sb82TGv2Cpytzbzz7tkeHc=
+github.com/aws/aws-sdk-go v1.35.28/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.0/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -122,6 +124,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
@@ -450,6 +453,10 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/pkg/adapter/awsdynamodbsource/adapter_test.go
+++ b/pkg/adapter/awsdynamodbsource/adapter_test.go
@@ -17,13 +17,19 @@ limitations under the License.
 package awsdynamodbsource
 
 import (
-	"errors"
+	"context"
+	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
 
@@ -31,199 +37,252 @@ import (
 	loggingtesting "knative.dev/pkg/logging/testing"
 )
 
-type mockedDynamoStreamsClient struct {
-	dynamodbstreamsiface.DynamoDBStreamsAPI
-	listStreamsOutput      dynamodbstreams.ListStreamsOutput
-	listStreamsOutputError error
+const (
+	tTableArnResource        = "table/MyTable"
+	tLatestStreamArnResource = "stream/1970-01-01T00:00:00.000"
+	tShardIDPrefix           = "shardId-00000000000000000000-000000" // + 3 digits appended for each shard
+)
 
-	describeStreamOutput      dynamodbstreams.DescribeStreamOutput
-	describeStreamOutputError error
+func TestAdapter(t *testing.T) {
+	// The test's data is pre-populated so the flow of records is
+	// uninterrupted until every record has been retrieved. We can
+	// therefore affirm something went wrong if the getRecords timer
+	// happens during the test.
+	const testTimeout = getRecordsPeriod
 
-	getShardIteratorOutput      dynamodbstreams.GetShardIteratorOutput
-	getShardIteratorOutputError error
+	const numShards = 3
+	const itersPerShard = 3
+	const expectEvents = numShards * itersPerShard * 3 // 3 hardcoded records per iterator
 
-	getRecordsOutput      dynamodbstreams.GetRecordsOutput
-	getRecordsOutputError error
-}
-
-func (m mockedDynamoStreamsClient) ListStreams(in *dynamodbstreams.ListStreamsInput) (*dynamodbstreams.ListStreamsOutput, error) {
-	return &m.listStreamsOutput, m.listStreamsOutputError
-}
-
-func (m mockedDynamoStreamsClient) DescribeStream(in *dynamodbstreams.DescribeStreamInput) (*dynamodbstreams.DescribeStreamOutput, error) {
-	return &m.describeStreamOutput, m.describeStreamOutputError
-}
-
-func (m mockedDynamoStreamsClient) GetShardIterator(in *dynamodbstreams.GetShardIteratorInput) (*dynamodbstreams.GetShardIteratorOutput, error) {
-	return &m.getShardIteratorOutput, m.getShardIteratorOutputError
-}
-
-func (m mockedDynamoStreamsClient) GetRecords(in *dynamodbstreams.GetRecordsInput) (*dynamodbstreams.GetRecordsOutput, error) {
-	return &m.getRecordsOutput, m.getRecordsOutputError
-}
-
-func TestGetStreams(t *testing.T) {
-	a := &adapter{
-		logger: loggingtesting.TestLogger(t),
-	}
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		listStreamsOutput:      dynamodbstreams.ListStreamsOutput{},
-		listStreamsOutputError: errors.New("fake getstreams error"),
-	}
-
-	streams, err := a.getStreams()
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(streams))
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		listStreamsOutput: dynamodbstreams.ListStreamsOutput{
-			Streams: []*dynamodbstreams.Stream{{}, {}},
-		},
-		listStreamsOutputError: nil,
-	}
-
-	streams, err = a.getStreams()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(streams))
-}
-
-func TestGetStreamsDescriptions(t *testing.T) {
-	a := &adapter{
-		logger: loggingtesting.TestLogger(t),
-	}
-
-	streams := []*dynamodbstreams.Stream{{}}
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		describeStreamOutput:      dynamodbstreams.DescribeStreamOutput{},
-		describeStreamOutputError: errors.New("fake describestream error"),
-	}
-
-	streamsDescriptions, err := a.getStreamsDescriptions(streams)
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(streamsDescriptions))
-
-	streams = []*dynamodbstreams.Stream{
-		{
-			StreamArn:   aws.String("foo"),
-			StreamLabel: aws.String("bar"),
-			TableName:   aws.String("fooTable"),
-		},
-	}
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		describeStreamOutput: dynamodbstreams.DescribeStreamOutput{
-			StreamDescription: &dynamodbstreams.StreamDescription{},
-		},
-		describeStreamOutputError: nil,
-	}
-
-	streamsDescriptions, err = a.getStreamsDescriptions(streams)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(streamsDescriptions))
-}
-
-func TestGetShardIterators(t *testing.T) {
-	a := &adapter{
-		logger: loggingtesting.TestLogger(t),
-	}
-
-	streamDescriptions := []*dynamodbstreams.StreamDescription{{
-		Shards: []*dynamodbstreams.Shard{{}},
-	}}
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		getShardIteratorOutput:      dynamodbstreams.GetShardIteratorOutput{},
-		getShardIteratorOutputError: errors.New("fake getsharditerator error"),
-	}
-
-	streamsDescriptions, err := a.getShardIterators(streamDescriptions)
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(streamsDescriptions))
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		describeStreamOutput: dynamodbstreams.DescribeStreamOutput{
-			StreamDescription: &dynamodbstreams.StreamDescription{},
-		},
-		describeStreamOutputError: nil,
-	}
-
-	streamsDescriptions, err = a.getShardIterators(streamDescriptions)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(streamsDescriptions))
-}
-
-func TestGetLatestRecords(t *testing.T) {
 	ceClient := adaptertest.NewTestClient()
 
-	a := &adapter{
-		logger:   loggingtesting.TestLogger(t),
-		ceClient: ceClient,
+	strClient := &standardMockDynamoDBStreamsClient{
+		shards: makeMockShards(numShards, itersPerShard),
 	}
 
-	shardIterator := aws.String("1")
-
-	a.dyndbClient = mockedDynamoStreamsClient{
-		getRecordsOutput:      dynamodbstreams.GetRecordsOutput{},
-		getRecordsOutputError: errors.New("fake getrecords error"),
+	a := adapter{
+		logger:         loggingtesting.TestLogger(t),
+		dyndbClient:    &standardMockDynamoDBClient{},
+		dyndbStrClient: strClient,
+		arn:            makeARN(tTableArnResource),
+		ceClient:       ceClient,
 	}
 
-	_, err := a.processLatestRecords(shardIterator)
-	assert.Error(t, err)
+	testCtx, testCancel := context.WithTimeout(context.Background(), testTimeout)
+	defer testCancel()
 
-	a.dyndbClient = mockedDynamoStreamsClient{
-		getRecordsOutput: dynamodbstreams.GetRecordsOutput{
-			Records: []*dynamodbstreams.Record{{
-				EventID:     aws.String("1"),
-				EventName:   aws.String("some event"),
-				EventSource: aws.String("some source"),
-			}},
-		},
-		getRecordsOutputError: nil,
+	startCtx, startCancel := context.WithCancel(testCtx)
+	defer startCancel()
+
+	errCh := make(chan error)
+	defer close(errCh)
+
+	go func() {
+		errCh <- a.Start(startCtx)
+	}()
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+poll:
+	for {
+		select {
+		case <-testCtx.Done():
+			t.Fatal("Timeout waiting for events")
+
+		case <-timer.C:
+			if len(ceClient.Sent()) >= expectEvents {
+				startCancel()
+				break poll
+			}
+			timer.Reset(5 * time.Millisecond)
+		}
 	}
 
-	_, err = a.processLatestRecords(shardIterator)
-	assert.NoError(t, err)
-}
+	// no matter what, Start() should always return after its context has
+	// been cancelled
+	select {
+	case <-testCtx.Done():
+		t.Fatal("Timeout waiting for Start to return")
 
-func TestSendCloudevent(t *testing.T) {
-	ceClient := adaptertest.NewTestClient()
-
-	a := &adapter{
-		logger:   loggingtesting.TestLogger(t),
-		table:    "fooTable",
-		ceClient: ceClient,
-	}
-
-	record := dynamodbstreams.Record{
-		EventID:     aws.String("1"),
-		EventName:   aws.String("some event"),
-		EventSource: aws.String("some source"),
-		Dynamodb: &dynamodbstreams.StreamRecord{
-			Keys: map[string]*dynamodb.AttributeValue{"key1": nil, "key2": nil},
-		},
-	}
-
-	// send multiple events to ensure we re-use buffers from strBuilderPool
-	const sendEvents = 5
-
-	for i := 0; i < sendEvents; i++ {
-		err := a.sendDynamoDBEvent(&record)
+	case err := <-errCh:
 		assert.NoError(t, err)
 	}
 
-	gotEvents := ceClient.Sent()
-	assert.Len(t, gotEvents, sendEvents, "Expect %d sent events", sendEvents)
+	// final assertion to ensure we didn't receive more events than expected
+	assert.Len(t, ceClient.Sent(), expectEvents)
 
-	wantData := `{"AwsRegion":null,"Dynamodb":{"ApproximateCreationDateTime":null,"Keys":{"key1":null,"key2":null},"NewImage":null,"OldImage":null,"SequenceNumber":null,"SizeBytes":null,"StreamViewType":null},"EventID":"1","EventName":"some event","EventSource":"some source","EventVersion":null,"UserIdentity":null}`
+	// asserting a single event suffices since the entire data set is mocked
+	ev := ceClient.Sent()[0]
+	assert.Contains(t, ev.Type(), "com.amazon.dynamodb.")
+	assert.Equal(t, "arn:aws:dynamodb:us-fake-0:123456789012:table/MyTable", ev.Source())
+	assert.Contains(t, []string{"id,name", "name,id"}, ev.Subject())
+}
 
-	for i := 0; i < sendEvents; i++ {
-		gotData := string(gotEvents[i].Data())
-		assert.EqualValues(t, wantData, gotData, "[%d] Compare sent data to expected", i)
-
-		subject := gotEvents[i].Subject()
-		assert.Contains(t, []string{"key1,key2", "key2,key1"}, subject,
-			`[%d] Subject contains keys "key1,key2" in any order`, i)
+// makeARN returns a fake DynamoDB ARN for the given resource.
+func makeARN(resource string) arn.ARN {
+	return arn.ARN{
+		Partition: "aws",
+		Service:   "dynamodb",
+		Region:    "us-fake-0",
+		AccountID: "123456789012",
+		Resource:  resource,
 	}
+}
+
+// standardMockDynamoDBClient is a mocked DynamoDB client which returns a
+// standard set of responses and never errors.
+type standardMockDynamoDBClient struct {
+	dynamodbiface.DynamoDBAPI
+}
+
+func (c *standardMockDynamoDBClient) DescribeTableWithContext(context.Context,
+	*dynamodb.DescribeTableInput, ...request.Option) (*dynamodb.DescribeTableOutput, error) {
+
+	latestStreamARN := makeARN(tLatestStreamArnResource).String()
+
+	return &dynamodb.DescribeTableOutput{
+		Table: &dynamodb.TableDescription{
+			LatestStreamArn: aws.String(latestStreamARN),
+		},
+	}, nil
+}
+
+// standardMockDynamoDBStreamsClient is a mocked DynamoDBStreams client which
+// returns a standard set of responses and never errors.
+type standardMockDynamoDBStreamsClient struct {
+	dynamodbstreamsiface.DynamoDBStreamsAPI
+
+	shards mockShards
+}
+
+func (c *standardMockDynamoDBStreamsClient) DescribeStreamWithContext(context.Context,
+	*dynamodbstreams.DescribeStreamInput, ...request.Option) (*dynamodbstreams.DescribeStreamOutput, error) {
+
+	shards := make([]*dynamodbstreams.Shard, 0, len(c.shards))
+
+	for id := range c.shards {
+		shards = append(shards, &dynamodbstreams.Shard{
+			ShardId: id,
+		})
+	}
+
+	sort.Slice(shards, func(i, j int) bool {
+		return *shards[i].ShardId < *shards[j].ShardId
+	})
+
+	return &dynamodbstreams.DescribeStreamOutput{
+		StreamDescription: &dynamodbstreams.StreamDescription{
+			StreamStatus: aws.String(dynamodbstreams.StreamStatusEnabled),
+			Shards:       shards,
+		},
+	}, nil
+}
+
+func (c *standardMockDynamoDBStreamsClient) GetShardIteratorWithContext(_ context.Context,
+	in *dynamodbstreams.GetShardIteratorInput, _ ...request.Option) (*dynamodbstreams.GetShardIteratorOutput, error) {
+
+	return &dynamodbstreams.GetShardIteratorOutput{
+		ShardIterator: c.shards[in.ShardId][0].name,
+	}, nil
+}
+
+func (c *standardMockDynamoDBStreamsClient) GetRecordsWithContext(_ context.Context,
+	in *dynamodbstreams.GetRecordsInput, _ ...request.Option) (*dynamodbstreams.GetRecordsOutput, error) {
+
+	var recs []*dynamodbstreams.Record
+	var nextIter *string
+
+	for _, iters := range c.shards {
+		for i, iter := range iters {
+			if *iter.name == *in.ShardIterator {
+				recs = iter.records
+
+				// erase records to simulate "LATEST" shard
+				// iterator type and prevent processing the
+				// same record more than once
+				iter.records = nil
+
+				// loop over shard iterators infinitely to
+				// simulate DynamoDB Streams API
+				nextIter = iters[(i+1)%len(iters)].name
+
+				break
+			}
+		}
+	}
+
+	return &dynamodbstreams.GetRecordsOutput{
+		Records:           recs,
+		NextShardIterator: nextIter,
+	}, nil
+}
+
+// mockShards mocks the data contained in some DynamoDB Streams Shards. It
+// represents the following structure:
+//
+// []shard id
+//    \_ [] shard iterator
+//           \_ [] record
+//
+type mockShards map[ /*shard id*/ *string][]*mockShardIterator
+type mockShardIterator struct {
+	name    *string
+	records []*dynamodbstreams.Record
+}
+
+// makeMockShards returns a set of mocked Shards.
+func makeMockShards(n, itersPerShard int) mockShards {
+	shards := make(mockShards, n)
+
+	for i := 0; i < n; i++ {
+		id := aws.String(fmt.Sprintf(tShardIDPrefix+"%03d", i+1))
+		shards[id] = makeMockIterators(itersPerShard, i+1)
+	}
+
+	return shards
+}
+
+// makeMockIterators returns a set of mocked ShardIterators for the given shard index.
+func makeMockIterators(n, shardIdx int) []*mockShardIterator {
+	// NOTE: shard iterators names are completely random in the "real" implementation
+
+	latestStreamARN := makeARN(tLatestStreamArnResource).String()
+
+	iters := make([]*mockShardIterator, n)
+
+	for i := 0; i < n; i++ {
+		iters[i] = &mockShardIterator{
+			name:    aws.String(fmt.Sprintf(latestStreamARN+"|1|AAA...shard%03d...%03d", shardIdx, i+1)),
+			records: makeMockRecords(shardIdx, i+1),
+		}
+	}
+
+	return iters
+}
+
+// makeMockRecords returns a set of mocked StreamRecords for the given shard
+// and iterator indexes (exactly 3, to keep the data set simple and predictable).
+func makeMockRecords(shardIdx, iteratorIdx int) []*dynamodbstreams.Record {
+	// NOTE: event IDs are completely random in the "real" implementation
+
+	return []*dynamodbstreams.Record{{
+		EventID:   aws.String(fmt.Sprintf("shard%03d-iterator%03d-001", shardIdx, iteratorIdx)),
+		EventName: aws.String(dynamodbstreams.OperationTypeInsert),
+		Dynamodb: &dynamodbstreams.StreamRecord{
+			Keys: map[string]*dynamodb.AttributeValue{"id": nil, "name": nil},
+		},
+	}, {
+		EventID:   aws.String(fmt.Sprintf("shard%03d-iterator%03d-002", shardIdx, iteratorIdx)),
+		EventName: aws.String(dynamodbstreams.OperationTypeModify),
+		Dynamodb: &dynamodbstreams.StreamRecord{
+			Keys: map[string]*dynamodb.AttributeValue{"id": nil, "name": nil},
+		},
+	}, {
+		EventID:   aws.String(fmt.Sprintf("shard%03d-iterator%03d-003", shardIdx, iteratorIdx)),
+		EventName: aws.String(dynamodbstreams.OperationTypeRemove),
+		Dynamodb: &dynamodbstreams.StreamRecord{
+			Keys: map[string]*dynamodb.AttributeValue{"id": nil, "name": nil},
+		},
+	}}
 }


### PR DESCRIPTION
Fixes #218 

This is a complete rewrite of the DynamoDB source, so beware that the PR review might be quite technical.

e2e tests written by @sameersbn uncovered serious issues with the DynamoDB source. In most cases, it doesn't process any event because it doesn't iterate over shards correctly.

The "correct" way to iterate over shards is to read the _next shard_ from the response to `GetRecords` API calls. `GetShardIterator` only returns the _initial_ iterator, but the records are not necessarily accessible at this particular iterator.

There is another quirk: the chain of `NextShardIterator`s returned by `GetRecords` is endless. The iterator only becomes `nil` when the shard gets sealed (marked as read only), which also happens regularly and automatically. Therefore, we need to run those records processors as background routines.

The documentation at https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html is limited but explains that shards are _ephemeral_  and can _split into multiple new shards_ automatically, so we also need to recheck the stream from time to time (every 15s in my code), which we never did before.

This implementation is inspired by the example at https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.LowLevel.Walkthrough.html, with all the concurrency added on top.





