### PR TITLE
sample: fix `DeliveryPolicy` in SNS samples

### DIFF
--- a/cmd/awssnssource/README.md
+++ b/cmd/awssnssource/README.md
@@ -20,7 +20,7 @@ endpoint is used to subscribe to the desired SNS topic on behalf of the user.
 
 * Register an AWS account
 * Create an [Access Key][doc-accesskey] in your AWS IAM dashboard.
-* Create a [SNS topic][doc-sns].
+* Create a Standard [SNS topic][doc-sns].
 
 ## Deployment to Kubernetes
 

--- a/config/samples/awssns-containersource.yaml
+++ b/config/samples/awssns-containersource.yaml
@@ -45,7 +45,9 @@ spec:
             { "DeliveryPolicy":
               {
                 "healthyRetryPolicy": {
-                  "numRetries": 5
+                  "numRetries": 3,
+                  "minDelayTarget": 20,
+                  "maxDelayTarget": 20
                 }
               }
             }

--- a/config/samples/awssns-sinkbinding.yaml
+++ b/config/samples/awssns-sinkbinding.yaml
@@ -71,7 +71,9 @@ spec:
             { "DeliveryPolicy":
               {
                 "healthyRetryPolicy": {
-                  "numRetries": 5
+                  "numRetries": 3,
+                  "minDelayTarget": 20,
+                  "maxDelayTarget": 20
                 }
               }
             }

--- a/config/samples/awssnssource.yaml
+++ b/config/samples/awssnssource.yaml
@@ -28,7 +28,9 @@ spec:
     DeliveryPolicy: |
       {
         "healthyRetryPolicy": {
-          "numRetries": 5
+          "numRetries": 3,
+          "minDelayTarget": 20,
+          "maxDelayTarget": 20
         }
       }
 


### PR DESCRIPTION
SNS source requires `numRetries`, `minDelayTarget` and `maxDelayTarget`
to be specified when `healthyRetryPolicy` is provided.