### PR TITLE
sqs: Set resources and limits

### DIFF
--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -18,6 +18,7 @@ package awssqssource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	kr "k8s.io/apimachinery/pkg/api/resource"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -73,6 +74,15 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
+
+			resource.Requests(
+				*kr.NewMilliQuantity(90, kr.DecimalSI), // 90m
+				*kr.NewQuantity(1024*18, kr.BinarySI),  // 18Mi
+			),
+			resource.Limits(
+				*kr.NewMilliQuantity(120, kr.DecimalSI), // 120m
+				*kr.NewQuantity(1024*30, kr.BinarySI),   // 30Mi
+			),
 		)
 	}
 }

--- a/pkg/reconciler/common/resource/container_test.go
+++ b/pkg/reconciler/common/resource/container_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -35,6 +36,8 @@ func TestNewContainer(t *testing.T) {
 		EnvVar("TEST_ENV2", "val2"),
 		Probe("/health", "health"),
 		EnvVarFromSecret("TEST_ENV3", "test-secret", "someKey"),
+		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
+		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
 
 	expectCont := &corev1.Container{
@@ -76,6 +79,16 @@ func TestNewContainer(t *testing.T) {
 					Path: "/health",
 					Port: intstr.FromString("health"),
 				},
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
 			},
 		},
 	}

--- a/pkg/reconciler/common/resource/deployment_test.go
+++ b/pkg/reconciler/common/resource/deployment_test.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -42,6 +43,8 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
+		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
 
 	expectKsvc := &appsv1.Deployment{
@@ -99,6 +102,16 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 									Path: "/health",
 									Port: intstr.FromString("health"),
 								},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+								corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+								corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
 							},
 						},
 					}},

--- a/pkg/reconciler/common/resource/deployment_test.go
+++ b/pkg/reconciler/common/resource/deployment_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestNewDeploymentWithDefaultContainer(t *testing.T) {
-	ksvc := NewDeployment(tNs, tName,
+	depl := NewDeployment(tNs, tName,
 		PodLabel("test.podlabel/2", "val2"),
 		Selector("test.selector/1", "val1"),
 		Port("h2c", 8080),
@@ -47,7 +47,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
 
-	expectKsvc := &appsv1.Deployment{
+	expectDepl := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: tNs,
 			Name:      tName,
@@ -120,17 +120,17 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		},
 	}
 
-	if d := cmp.Diff(expectKsvc, ksvc); d != "" {
+	if d := cmp.Diff(expectDepl, depl); d != "" {
 		t.Errorf("Unexpected diff: (-:expect, +:got) %s", d)
 	}
 }
 
 func TestNewDeploymentWithCustomContainer(t *testing.T) {
-	ksvc := NewDeployment(tNs, tName,
+	depl := NewDeployment(tNs, tName,
 		Container(&corev1.Container{Name: "foo"}),
 	)
 
-	expectKsvc := &appsv1.Deployment{
+	expectDepl := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: tNs,
 			Name:      tName,
@@ -146,7 +146,7 @@ func TestNewDeploymentWithCustomContainer(t *testing.T) {
 		},
 	}
 
-	if d := cmp.Diff(expectKsvc, ksvc); d != "" {
+	if d := cmp.Diff(expectDepl, depl); d != "" {
 		t.Errorf("Unexpected diff: (-:expect, +:got) %s", d)
 	}
 }

--- a/pkg/reconciler/common/resource/knservice_test.go
+++ b/pkg/reconciler/common/resource/knservice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -40,6 +41,8 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
+		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
 
 	expectKsvc := &servingv1.Service{
@@ -87,6 +90,16 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 										HTTPGet: &corev1.HTTPGetAction{
 											Path: "/health",
 										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+										corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+										corev1.ResourceMemory: *resource.NewQuantity(1024*1024*100, resource.BinarySI),
 									},
 								},
 							}},


### PR DESCRIPTION
Based on observations from a load test with 100,000 messages, with 1 then 10 replicas (1 worker per replica for the time being).

![image](https://user-images.githubusercontent.com/3299086/100277972-5be68080-2f64-11eb-87e0-40248c3ba714.png)

---

I'm dropping the corresponding throughput profile here as a bonus (~40 msg/s _per instance_ when the queue and receiver are both located in the U.S.):

![result-thrpt](https://user-images.githubusercontent.com/3299086/100278367-078fd080-2f65-11eb-939e-3aa02f7f4bd5.png)