### PR TITLE
sqs: Optimize for concurrency

### DIFF
--- a/cmd/awssqssource/main.go
+++ b/cmd/awssqssource/main.go
@@ -17,11 +17,30 @@ limitations under the License.
 package main
 
 import (
+	"runtime"
+
 	"knative.dev/eventing/pkg/adapter/v2"
 
 	"github.com/triggermesh/aws-event-sources/pkg/adapter/awssqssource"
 )
 
 func main() {
+	setMaxProcs(runtime.NumCPU())
+
 	adapter.Main("awssqssource", awssqssource.NewEnvConfig, awssqssource.NewAdapter)
+}
+
+// setMaxProcs sets the number of threads that can be used by the current
+// process.
+//
+// Knative uses uber-go/automaxprocs to automatically determine the number of
+// threads (GOMAXPROCS) available to the process based on CPU quotas (e.g.
+// 'cpu.request <= 1' translates to 1 thread, regardless of the number of
+// physical cores).
+// This event source has a very predictable CPU profile: it spends most of its
+// time sending network requests without performing any computation on the
+// results, so we assume the defined CPU limit allows all CPU cores to be used
+// without starving on CPU time.
+func setMaxProcs(procs int) int {
+	return runtime.GOMAXPROCS(procs)
 }

--- a/pkg/adapter/awssqssource/adapter.go
+++ b/pkg/adapter/awssqssource/adapter.go
@@ -18,13 +18,12 @@ package awssqssource
 
 import (
 	"context"
-	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
@@ -38,16 +37,12 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/triggermesh/aws-event-sources/pkg/adapter/common"
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
 
-// Highest possible value for the MaxNumberOfMessages request parameter.
-// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
-const maxReceiveMsgBatchSize = 10
-
-// Highest possible duration of a long polling request.
-// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
-const maxLongPollingWaitTimeSeconds = 20
+const (
+	logfieldMsgID  = "msgID"
+	logfieldMsgIDs = "msgIDs"
+)
 
 // envConfig is a set parameters sourced from the environment for the source's
 // adapter.
@@ -65,6 +60,11 @@ type adapter struct {
 	ceClient  cloudevents.Client
 
 	arn arn.ARN
+
+	processQueue chan *sqs.Message
+	deleteQueue  chan *sqs.Message
+
+	deletePeriod time.Duration
 }
 
 // NewEnvConfig returns an accessor for the source's adapter envConfig.
@@ -81,9 +81,12 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 	arn := common.MustParseARN(env.ARN)
 
 	cfg := session.Must(session.NewSession(aws.NewConfig().
-		WithRegion(arn.Region).
-		WithMaxRetries(5),
+		WithRegion(arn.Region),
 	))
+
+	// allocate generous buffer sizes to avoid blocking often
+	const batchSizePerProcMultiplier = 2
+	queueBufferSize := runtime.GOMAXPROCS(-1) * maxReceiveMsgBatchSize * batchSizePerProcMultiplier
 
 	return &adapter{
 		logger: logger,
@@ -92,6 +95,11 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		ceClient:  ceClient,
 
 		arn: arn,
+
+		processQueue: make(chan *sqs.Message, queueBufferSize),
+		deleteQueue:  make(chan *sqs.Message, queueBufferSize),
+
+		deletePeriod: maxDeleteMsgPeriod,
 	}
 }
 
@@ -106,36 +114,38 @@ func (a *adapter) Start(ctx context.Context) error {
 	queueURL := *url.QueueUrl
 	a.logger.Infof("Listening to SQS queue at URL: %s", queueURL)
 
-	backoff := common.NewBackoff(1 * time.Millisecond)
+	msgCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	err = backoff.Run(ctx.Done(), func(ctx context.Context) (bool, error) {
-		messages, err := a.getMessages(queueURL)
-		if err != nil {
-			a.logger.Errorw("Failed to get messages from the SQS queue", zap.Error(err))
-			return false, nil
-		}
+	var wg sync.WaitGroup
 
-		if len(messages) == 0 {
-			return true, nil
-		}
+	for i := 0; i < runtime.GOMAXPROCS(-1); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.runMessagesReceiver(msgCtx, queueURL)
+		}()
 
-		sent, err := a.sendSQSEvents(messages)
-		if err != nil {
-			// log the error but proceed with deleting the events
-			// that were successfully sent to the sink
-			a.logger.Errorw("Failed to send events to the sink", zap.Error(err))
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.runMessagesProcessor(msgCtx)
+		}()
+	}
 
-		err = a.deleteMessages(queueURL, sent)
-		if err != nil {
-			a.logger.Errorw("Failed to delete message from the SQS queue", zap.Error(err))
-			return false, nil
-		}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		a.runMessagesDeleter(msgCtx, queueURL)
+	}()
 
-		return true, nil
-	})
+	<-ctx.Done()
+	cancel()
 
-	return err
+	a.logger.Info("Waiting for message handlers to terminate")
+	wg.Wait()
+
+	return nil
 }
 
 // queueLookup finds the URL for a given queue name in the user's env.
@@ -146,158 +156,25 @@ func (a *adapter) queueLookup(queueName string) (*sqs.GetQueueUrlOutput, error) 
 	})
 }
 
-// getMessages returns the parsed messages from SQS if any. If an error
-// occurs that error will be returned.
-func (a *adapter) getMessages(queueURL string) ([]*sqs.Message, error) {
-	params := sqs.ReceiveMessageInput{
-		AttributeNames:      aws.StringSlice([]string{sqs.QueueAttributeNameAll}),
-		QueueUrl:            &queueURL,
-		MaxNumberOfMessages: aws.Int64(maxReceiveMsgBatchSize),
-		WaitTimeSeconds:     aws.Int64(maxLongPollingWaitTimeSeconds),
-	}
-	resp, err := a.sqsClient.ReceiveMessage(&params)
-	if err != nil {
-		return nil, err
-	}
-	return resp.Messages, nil
-}
-
-// sendSQSEvents sends SQS messages to the event sink.
-func (a *adapter) sendSQSEvents(msgs []*sqs.Message) (sent []*sqs.Message, err error) {
-	// NOTE(antoineco): the CloudEvents SDK for Go doesn't support the
-	// batched content mode, although it is defined in the spec.
-	// https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#33-batched-content-mode
-
-	concurrentSent := concurrentMsgSlice{
-		msgs: make([]*sqs.Message, 0, len(msgs)),
-	}
-
-	errCh := make(chan error, len(msgs))
-	defer close(errCh)
-
-	for _, msg := range msgs {
-		a.logger.Debugf("Processing messages ID %s", *msg.MessageId)
-
-		go func(msg *sqs.Message) {
-			err := sendSQSEvent(a.ceClient, msg, a.arn)
-			if err != nil {
-				errCh <- fmt.Errorf("message ID %s: %w", *msg.MessageId, err)
-				return
-			}
-
-			concurrentSent.append(msg)
-
-			// always write to errCh to notify that sendSQSEvent returned
-			errCh <- err
-		}(msg)
-	}
-
-	var errs []error
-
-	for i := 0; i < cap(errCh); i++ {
-		if err := <-errCh; err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	if len(errs) > 0 {
-		err = &errList{errs: errs}
-	}
-
-	return concurrentSent.msgs, err
-}
-
-// concurrentMsgSlice protects writes to a slice of Messages using a mutex.
-type concurrentMsgSlice struct {
-	sync.Mutex
-	msgs []*sqs.Message
-}
-
-// append appends a new Message to the Messages slice in a thread-safe manner.
-func (ms *concurrentMsgSlice) append(msg *sqs.Message) {
-	ms.Lock()
-	ms.msgs = append(ms.msgs, msg)
-	ms.Unlock()
-}
-
-// sendSQSEvent sends a single SQS message to the event sink.
-func sendSQSEvent(cli cloudevents.Client, msg *sqs.Message, queueARN arn.ARN) error {
-	// TODO: work on CE attributes contract
-	subject, exist := msg.Attributes[sqs.MessageSystemAttributeNameSenderId]
-	if !exist {
-		subject = msg.MessageId
-	}
-
-	event := cloudevents.NewEvent()
-	event.SetType(v1alpha1.AWSEventType(queueARN.Service, v1alpha1.AWSSQSGenericEventType))
-	event.SetSubject(*subject)
-	event.SetSource(queueARN.String())
-	event.SetID(*msg.MessageId)
-	if err := event.SetData(cloudevents.ApplicationJSON, msg); err != nil {
-		return fmt.Errorf("failed to set event data: %w", err)
-	}
-
-	if result := cli.Send(context.Background(), event); !cloudevents.IsACK(result) {
-		return result
-	}
-	return nil
-}
-
-// deleteMessages deletes messages from the SQS queue.
-func (a *adapter) deleteMessages(queueURL string, msgs []*sqs.Message) error {
-	deleteEntries := make([]*sqs.DeleteMessageBatchRequestEntry, len(msgs))
-	for i, msg := range msgs {
-		deleteEntries[i] = &sqs.DeleteMessageBatchRequestEntry{
-			Id:            msg.MessageId,
-			ReceiptHandle: msg.ReceiptHandle,
-		}
-	}
-
-	deleteParams := &sqs.DeleteMessageBatchInput{
-		QueueUrl: &queueURL,
-		Entries:  deleteEntries,
-	}
-	if _, err := a.sqsClient.DeleteMessageBatch(deleteParams); err != nil {
-		return err
-	}
-
-	if a.logger.Desugar().Core().Enabled(zapcore.DebugLevel) {
-		msgIds := make([]string, len(deleteEntries))
-		for i, msg := range deleteEntries {
-			msgIds[i] = *msg.Id
-		}
-		a.logger.Debugf("Deleted message IDs %v", msgIds)
-	}
-
-	return nil
-}
-
-type errList struct {
-	errs []error
-}
-
-var _ error = (*errList)(nil)
-
-// Error implements the error interface.
-func (e *errList) Error() string {
-	if e == nil || len(e.errs) == 0 {
+// prettifyBatchResultErrors returns a pretty string representing a list of
+// batch failures.
+func prettifyBatchResultErrors(errs []*sqs.BatchResultErrorEntry) string {
+	if len(errs) == 0 {
 		return ""
 	}
 
-	if len(e.errs) == 1 {
-		return e.errs[0].Error()
-	}
+	var errStr strings.Builder
 
-	var b strings.Builder
+	errStr.WriteByte('[')
 
-	b.WriteByte('[')
-	for i, err := range e.errs {
-		b.WriteString(err.Error())
-		if i != len(e.errs)-1 {
-			b.WriteString(", ")
+	for i, f := range errs {
+		errStr.WriteString(f.String())
+		if i+1 < len(errs) {
+			errStr.WriteByte(',')
 		}
 	}
-	b.WriteByte(']')
 
-	return b.String()
+	errStr.WriteByte(']')
+
+	return errStr.String()
 }

--- a/pkg/adapter/awssqssource/delete.go
+++ b/pkg/adapter/awssqssource/delete.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2019-2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqssource
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+)
+
+const (
+	// Highest possible value for the MaxNumberOfMessages request parameter.
+	// Undocumented, but exceeding that number returns "Maximum number of
+	// entries per request are 10. You have sent ...".
+	maxDeleteMsgBatchSize = 10
+
+	// Maximum time to wait between calls to DeleteMessageBatch, which
+	// marks messages as processed.
+	maxDeleteMsgPeriod = 3 * time.Second
+
+	// Calls to DeleteMessage are cancelled when they exceed this duration.
+	deleteRequestTimeout = 10 * time.Second
+)
+
+// A message deleter deletes messages from the SQS queue to mark them as
+// processed. It does this by accumulating references of SQS messages into a
+// deletion buffer until this buffer has reached its capacity or until a timer
+// expires, whichever happens first.
+func (a *adapter) runMessagesDeleter(ctx context.Context, queueURL string) {
+	delMsgBuf := make(messageDeleteBuffer, maxDeleteMsgBatchSize)
+
+	t := time.NewTimer(a.deletePeriod)
+
+	// calling this function blocks the processing of received messages temporarily.
+	handleDeletion := func() {
+		defer t.Reset(a.deletePeriod)
+
+		if len(delMsgBuf) == 0 {
+			return
+		}
+
+		a.logger.Debugw("Deleting messages", zap.Array(logfieldMsgIDs, delMsgBuf))
+
+		if err := deleteMessages(ctx, a.sqsClient, queueURL, delMsgBuf); err != nil {
+			// NOTE(antoineco): If the batch deletion fails, SQS
+			// will re-add those messages to the queue after the
+			// visibility timeout has expired, causing a
+			// re-delivery (at-least-once delivery).
+			a.logger.Errorw("Failed to delete messages from the SQS queue", zap.Error(err))
+		}
+
+		// reuse the same buffer to avoid new allocations
+		for k := range delMsgBuf {
+			delete(delMsgBuf, k)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// always flush current message buffer upon termination
+			ctx = context.Background()
+			handleDeletion()
+
+			return
+
+		case <-t.C:
+			handleDeletion()
+
+		case msg := <-a.deleteQueue:
+			delMsgBuf[*msg.MessageId] = *msg.ReceiptHandle
+
+			if len(delMsgBuf) == maxDeleteMsgBatchSize {
+				handleDeletion()
+			}
+		}
+	}
+}
+
+// messageDeleteBuffer holds references to SQS messages that have already been
+// processed and should be deleted from the SQS queue.
+type messageDeleteBuffer map[ /*MessageId*/ string] /*ReceiptHandle*/ string
+
+var _ zapcore.ArrayMarshaler = (messageDeleteBuffer)(nil)
+
+// MarshalLogArray implements zapcore.ArrayMarshaler.
+func (mdb messageDeleteBuffer) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	for id := range mdb {
+		arr.AppendString(id)
+	}
+	return nil
+}
+
+// deleteMessages deletes messages from the SQS queue.
+func deleteMessages(ctx context.Context, cli sqsiface.SQSAPI, queueURL string, msgs messageDeleteBuffer) error {
+	deleteEntries := make([]*sqs.DeleteMessageBatchRequestEntry, 0, len(msgs))
+	for id, handle := range msgs {
+		deleteEntries = append(deleteEntries, &sqs.DeleteMessageBatchRequestEntry{
+			Id:            aws.String(id),
+			ReceiptHandle: aws.String(handle),
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteRequestTimeout)
+	defer cancel()
+
+	in := &sqs.DeleteMessageBatchInput{
+		QueueUrl: &queueURL,
+		Entries:  deleteEntries,
+	}
+
+	out, err := cli.DeleteMessageBatchWithContext(ctx, in)
+	if err != nil {
+		return err
+	}
+	if len(out.Failed) > 0 {
+		return errors.New(prettifyBatchResultErrors(out.Failed))
+	}
+
+	return nil
+}

--- a/pkg/adapter/awssqssource/process.go
+++ b/pkg/adapter/awssqssource/process.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2019-2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqssource
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+)
+
+// A message processor processes SQS messages (sends as CloudEvent)
+// sequentially, as soon as they are written to processQueue.
+func (a *adapter) runMessagesProcessor(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case msg := <-a.processQueue:
+			a.logger.Debugw("Processing message", zap.String(logfieldMsgID, *msg.MessageId))
+
+			if err := sendSQSEvent(ctx, a.ceClient, &a.arn, msg); err != nil {
+				a.logger.Errorw("Failed to send event to the sink", zap.Error(err),
+					zap.String(logfieldMsgID, *msg.MessageId))
+
+				continue
+			}
+
+			a.deleteQueue <- msg
+		}
+	}
+}
+
+// sendSQSEvent sends a single SQS message as a CloudEvent to the event sink.
+func sendSQSEvent(ctx context.Context, cli cloudevents.Client, arn *arn.ARN, msg *sqs.Message) error {
+	// TODO: work on CE attributes contract
+	subject, exist := msg.Attributes[sqs.MessageSystemAttributeNameSenderId]
+	if !exist {
+		subject = msg.MessageId
+	}
+
+	event := cloudevents.NewEvent()
+	event.SetType(v1alpha1.AWSEventType(arn.Service, v1alpha1.AWSSQSGenericEventType))
+	event.SetSubject(*subject)
+	event.SetSource(arn.String())
+	event.SetID(*msg.MessageId)
+	if err := event.SetData(cloudevents.ApplicationJSON, msg); err != nil {
+		return fmt.Errorf("setting CloudEvent data: %w", err)
+	}
+
+	if result := cli.Send(ctx, event); !cloudevents.IsACK(result) {
+		return result
+	}
+	return nil
+}

--- a/pkg/adapter/awssqssource/receive.go
+++ b/pkg/adapter/awssqssource/receive.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2019-2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqssource
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+)
+
+const (
+	// Highest possible value for the MaxNumberOfMessages request parameter.
+	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
+	maxReceiveMsgBatchSize = 10
+
+	// Longest possible duration of a long polling request.
+	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+	maxLongPollingWaitTimeSeconds = 20
+
+	// Visibility timeout to set on all messages received by this event source.
+	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+	visibilityTimeoutSeconds = 30
+
+	// Duration between calls to ReceiveMessage when the previous call didn't return any message.
+	receiveMsgPeriod = 3 * time.Second
+)
+
+// A message receiver establishes long-lived connection to the SQS queue to
+// fetch new messages.
+func (a *adapter) runMessagesReceiver(ctx context.Context, queueURL string) {
+	t := time.NewTimer(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-t.C:
+			messages, err := receiveMessages(ctx, a.sqsClient, queueURL)
+			if err != nil {
+				a.logger.Errorw("Failed to get messages from the SQS queue", zap.Error(err))
+				t.Reset(1 * time.Second)
+				continue
+			}
+
+			nextRequestDelay := receiveMsgPeriod
+			if l := len(messages); l > 0 {
+				// keep iterating immediately if any message was
+				// received, so that bursts of new messages are
+				// processed quickly
+				nextRequestDelay = 0
+
+				a.logger.Debugw("Received "+strconv.Itoa(l)+" message(s)",
+					zap.Array(logfieldMsgID, messageList(messages)))
+			}
+
+			for _, msg := range messages {
+				a.processQueue <- msg
+			}
+
+			t.Reset(nextRequestDelay)
+		}
+	}
+}
+
+type messageList []*sqs.Message
+
+var _ zapcore.ArrayMarshaler = (messageList)(nil)
+
+// MarshalLogArray implements zapcore.ArrayMarshaler.
+func (ml messageList) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	for _, m := range ml {
+		arr.AppendString(*m.MessageId)
+	}
+	return nil
+}
+
+// receiveMessages returns a batch of messages read from the SQS queue, if any
+// is available.
+func receiveMessages(ctx context.Context, cli sqsiface.SQSAPI, queueURL string) ([]*sqs.Message, error) {
+	resp, err := cli.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
+		AttributeNames:      aws.StringSlice([]string{sqs.QueueAttributeNameAll}),
+		QueueUrl:            &queueURL,
+		MaxNumberOfMessages: aws.Int64(maxReceiveMsgBatchSize),
+		WaitTimeSeconds:     aws.Int64(maxLongPollingWaitTimeSeconds),
+		VisibilityTimeout:   aws.Int64(visibilityTimeoutSeconds),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Messages, nil
+}

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -80,7 +80,7 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 				*kr.NewQuantity(1024*1024*18, kr.BinarySI), // 18Mi
 			),
 			resource.Limits(
-				*kr.NewMilliQuantity(120, kr.DecimalSI),    // 120m
+				*kr.NewMilliQuantity(200, kr.DecimalSI),    // 200m
 				*kr.NewQuantity(1024*1024*30, kr.BinarySI), // 30Mi
 			),
 		)


### PR DESCRIPTION
Rewrite of the source adapter to spawn concurrent message processors instead of executing a single loop sequentially.

The number of receivers and senders is based on the number of available CPU cores.

Closes #222 