### PR TITLE
Report SQS source metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.5.1
+	go.opencensus.io v0.22.5
 	go.uber.org/zap v1.16.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8

--- a/pkg/adapter/awssqssource/adapter_test.go
+++ b/pkg/adapter/awssqssource/adapter_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	adaptertest "knative.dev/eventing/pkg/adapter/v2/test"
 	loggingtesting "knative.dev/pkg/logging/testing"
 )
@@ -78,8 +79,13 @@ func TestAdapter(t *testing.T) {
 				availMsgs: makeMockMessages(tc.numMsgs),
 			}
 
+			mt := &pkgadapter.MetricTag{}
+
 			a := adapter{
 				logger: loggingtesting.TestLogger(t),
+
+				mt: mt,
+				sr: mustNewStatsReporter(mt),
 
 				sqsClient: sqsCli,
 				ceClient:  ceCli,

--- a/pkg/adapter/awssqssource/delete.go
+++ b/pkg/adapter/awssqssource/delete.go
@@ -90,6 +90,8 @@ func (a *adapter) runMessagesDeleter(ctx context.Context, queueURL string) {
 			handleDeletion()
 
 		case msg := <-a.deleteQueue:
+			a.sr.reportMessageDequeuedDeleteCount()
+
 			delMsgBuf[*msg.MessageId] = *msg.ReceiptHandle
 
 			if len(delMsgBuf) == maxDeleteMsgBatchSize {

--- a/pkg/adapter/awssqssource/process.go
+++ b/pkg/adapter/awssqssource/process.go
@@ -39,6 +39,8 @@ func (a *adapter) runMessagesProcessor(ctx context.Context) {
 			return
 
 		case msg := <-a.processQueue:
+			a.sr.reportMessageDequeuedProcessCount()
+
 			a.logger.Debugw("Processing message", zap.String(logfieldMsgID, *msg.MessageId))
 
 			if err := sendSQSEvent(ctx, a.ceClient, &a.arn, msg); err != nil {
@@ -49,6 +51,7 @@ func (a *adapter) runMessagesProcessor(ctx context.Context) {
 			}
 
 			a.deleteQueue <- msg
+			a.sr.reportMessageEnqueuedDeleteCount()
 		}
 	}
 }

--- a/pkg/adapter/awssqssource/receive.go
+++ b/pkg/adapter/awssqssource/receive.go
@@ -77,6 +77,7 @@ func (a *adapter) runMessagesReceiver(ctx context.Context, queueURL string) {
 
 			for _, msg := range messages {
 				a.processQueue <- msg
+				a.sr.reportMessageEnqueuedProcessCount()
 			}
 
 			t.Reset(nextRequestDelay)

--- a/pkg/adapter/awssqssource/stats_reporter.go
+++ b/pkg/adapter/awssqssource/stats_reporter.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqssource
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/metrics/metricskey"
+)
+
+const (
+	metricNameQueueCapacityProcess    = "queue_capacity_process"
+	metricNameQueueCapacityDelete     = "queue_capacity_delete"
+	metricNameMsgEnqueuedProcessCount = "message_enqueued_process_count"
+	metricNameMsgDequeuedProcessCount = "message_dequeued_process_count"
+	metricNameMsgEnqueuedDeleteCount  = "message_enqueued_delete_count"
+	metricNameMsgDequeuedDeleteCount  = "message_dequeued_delete_count"
+)
+
+var (
+	tagKeyResourceGroup = tag.MustNewKey(metricskey.LabelResourceGroup)
+	tagKeyNamespace     = tag.MustNewKey(metricskey.LabelNamespaceName)
+	tagKeyName          = tag.MustNewKey(metricskey.LabelName)
+)
+
+// queueCapacityProcessM records the capacity of the processing queue.
+var queueCapacityProcessM = stats.Int64(
+	metricNameQueueCapacityProcess,
+	"Number of items that can be buffered in the processing queue",
+	stats.UnitDimensionless,
+)
+
+// queueCapacityDeleteM records the capacity of the deletion queue.
+var queueCapacityDeleteM = stats.Int64(
+	metricNameQueueCapacityDelete,
+	"Number of items that can be buffered in the deletion queue",
+	stats.UnitDimensionless,
+)
+
+// msgEnqueuedProcessCountM records the number of SQS messages that have been
+// put onto the processing queue.
+var msgEnqueuedProcessCountM = stats.Int64(
+	metricNameMsgEnqueuedProcessCount,
+	"Number of SQS messages that have been put onto the processing queue",
+	stats.UnitDimensionless,
+)
+
+// msgDequeuedProcessCountM records the number of SQS messages that have been
+// fetched from the processing queue.
+var msgDequeuedProcessCountM = stats.Int64(
+	metricNameMsgDequeuedProcessCount,
+	"Number of SQS messages that have been fetched from the processing queue",
+	stats.UnitDimensionless,
+)
+
+// msgEnqueuedDeleteCountM records the number of SQS messages that have been
+// put onto the deletion queue.
+var msgEnqueuedDeleteCountM = stats.Int64(
+	metricNameMsgEnqueuedDeleteCount,
+	"Number of SQS messages that have been put onto the deletion queue",
+	stats.UnitDimensionless,
+)
+
+// msgDequeuedDeleteCountM records the number of SQS messages that have been
+// fetched from the deletion queue.
+var msgDequeuedDeleteCountM = stats.Int64(
+	metricNameMsgDequeuedDeleteCount,
+	"Number of SQS messages that have been fetched from the deletion queue",
+	stats.UnitDimensionless,
+)
+
+// registerStatsView registers an OpenCensus stats view for the source's metrics.
+func registerStatsView() error {
+	tagKeys := []tag.Key{
+		tagKeyResourceGroup,
+		tagKeyNamespace,
+		tagKeyName,
+	}
+
+	return view.Register(
+		&view.View{
+			Measure:     queueCapacityProcessM,
+			Description: queueCapacityProcessM.Description(),
+			Aggregation: view.LastValue(),
+			TagKeys:     tagKeys,
+		},
+		&view.View{
+			Measure:     queueCapacityDeleteM,
+			Description: queueCapacityDeleteM.Description(),
+			Aggregation: view.LastValue(),
+			TagKeys:     tagKeys,
+		},
+		&view.View{
+			Measure:     msgEnqueuedProcessCountM,
+			Description: msgEnqueuedProcessCountM.Description(),
+			Aggregation: view.Count(),
+			TagKeys:     tagKeys,
+		},
+		&view.View{
+			Measure:     msgDequeuedProcessCountM,
+			Description: msgDequeuedProcessCountM.Description(),
+			Aggregation: view.Count(),
+			TagKeys:     tagKeys,
+		},
+		&view.View{
+			Measure:     msgEnqueuedDeleteCountM,
+			Description: msgEnqueuedDeleteCountM.Description(),
+			Aggregation: view.Count(),
+			TagKeys:     tagKeys,
+		},
+		&view.View{
+			Measure:     msgDequeuedDeleteCountM,
+			Description: msgDequeuedDeleteCountM.Description(),
+			Aggregation: view.Count(),
+			TagKeys:     tagKeys,
+		},
+	)
+}
+
+// statsReporter collects and reports stats about the event source.
+type statsReporter struct {
+	// context that holds pre-populated OpenCensus tags
+	tagsCtx context.Context
+}
+
+// mustNewStatsReporter returns a new statsReporter initialized with the given
+// tags and panics in case of error.
+func mustNewStatsReporter(tags *pkgadapter.MetricTag) *statsReporter {
+	ctx, err := tag.New(context.Background(),
+		tag.Insert(tagKeyResourceGroup, tags.ResourceGroup),
+		tag.Insert(tagKeyNamespace, tags.Namespace),
+		tag.Insert(tagKeyName, tags.Name),
+	)
+	if err != nil {
+		panic(fmt.Errorf("error creating OpenCensus tags: %w", err))
+	}
+
+	return &statsReporter{
+		tagsCtx: ctx,
+	}
+}
+
+// reportQueueCapacityProcess sets the value of queueCapacityProcessM.
+func (r *statsReporter) reportQueueCapacityProcess(cap int) {
+	metrics.Record(r.tagsCtx, queueCapacityProcessM.M(int64(cap)))
+}
+
+// reportQueueCapacityDelete sets the value of queueCapacityDeleteM.
+func (r *statsReporter) reportQueueCapacityDelete(cap int) {
+	metrics.Record(r.tagsCtx, queueCapacityDeleteM.M(int64(cap)))
+}
+
+// reportMessageEnqueuedProcessCount increments msgEnqueuedProcessCountM.
+func (r *statsReporter) reportMessageEnqueuedProcessCount() {
+	metrics.Record(r.tagsCtx, msgEnqueuedProcessCountM.M(1))
+}
+
+// reportMessageDequeuedProcessCount increments msgDequeuedProcessCountM.
+func (r *statsReporter) reportMessageDequeuedProcessCount() {
+	metrics.Record(r.tagsCtx, msgDequeuedProcessCountM.M(1))
+}
+
+// reportMessageEnqueuedDeleteCount increments msgEnqueuedDeleteCountM.
+func (r *statsReporter) reportMessageEnqueuedDeleteCount() {
+	metrics.Record(r.tagsCtx, msgEnqueuedDeleteCountM.M(1))
+}
+
+// reportMessageDequeuedDeleteCount increments msgDequeuedDeleteCountM.
+func (r *statsReporter) reportMessageDequeuedDeleteCount() {
+	metrics.Record(r.tagsCtx, msgDequeuedDeleteCountM.M(1))
+}

--- a/pkg/adapter/awssqssource/stats_reporter.go
+++ b/pkg/adapter/awssqssource/stats_reporter.go
@@ -90,15 +90,16 @@ var msgDequeuedDeleteCountM = stats.Int64(
 	stats.UnitDimensionless,
 )
 
-// registerStatsView registers an OpenCensus stats view for the source's metrics.
-func registerStatsView() error {
+// mustRegisterStatsView registers an OpenCensus stats view for the source's
+// metrics and panics in case of error.
+func mustRegisterStatsView() {
 	tagKeys := []tag.Key{
 		tagKeyResourceGroup,
 		tagKeyNamespace,
 		tagKeyName,
 	}
 
-	return view.Register(
+	err := view.Register(
 		&view.View{
 			Measure:     queueCapacityProcessM,
 			Description: queueCapacityProcessM.Description(),
@@ -136,6 +137,9 @@ func registerStatsView() error {
 			TagKeys:     tagKeys,
 		},
 	)
+	if err != nil {
+		panic(fmt.Errorf("error registering OpenCensus stats view: %w", err))
+	}
 }
 
 // statsReporter collects and reports stats about the event source.

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -75,6 +75,8 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 
+			resource.Port("metrics", 9090),
+
 			// CPU throttling can be observed below a limit of 1,
 			// although the CPU usage under load remains below 400m.
 			resource.Requests(


### PR DESCRIPTION
Closes #229

Exposes the following Prometheus metrics via OpenCensus:

* `queue_capacity_process`
* `queue_capacity_delete`
* `message_enqueued_process_count`
* `message_dequeued_process_count`
* `message_enqueued_delete_count`
* `message_dequeued_delete_count`

Those metrics can be used to monitor the queues' depth, as shown in the sample dashboard below:

![sqs-dash-1](https://user-images.githubusercontent.com/3299086/101289740-a5ee2280-37fe-11eb-8ddd-e89a3ed4d77e.png)
