### PR TITLE
Fix case of AWSCloudWatchLogsSource in CRD

### DIFF
--- a/config/300-awscloudwatchlogs.yaml
+++ b/config/300-awscloudwatchlogs.yaml
@@ -29,7 +29,7 @@ spec:
   group: sources.triggermesh.io
   scope: Namespaced
   names:
-    kind: awscloudwatchlogssource
+    kind: AWSCloudWatchLogsSource
     plural: awscloudwatchlogssources
     categories:
     - all


### PR DESCRIPTION
Fixes the following error:
```
E1224 10:23:33.329854       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1alpha1.AWSCloudWatchLogsSource: no kind "awscloudwatchlogssourceList" is registered for version "sources.triggermesh.io/v1alpha1" in scheme "pkg/runtime/scheme.go:101"
```