### PR TITLE
Add health package to serve HTTP health probes

### DIFF
--- a/pkg/adapter/awscognitouserpoolsource/adapter_test.go
+++ b/pkg/adapter/awscognitouserpoolsource/adapter_test.go
@@ -40,6 +40,10 @@ func (m mockedCognitoUserPoolClient) ListUsers(in *cognitoidentityprovider.ListU
 	return &m.listUsersOutput, nil
 }
 
+func (mockedCognitoUserPoolClient) DescribeUserPool(*cognitoidentityprovider.DescribeUserPoolInput) (*cognitoidentityprovider.DescribeUserPoolOutput, error) {
+	return &cognitoidentityprovider.DescribeUserPoolOutput{}, nil
+}
+
 func TestListUsers(t *testing.T) {
 	user := cognitoidentityprovider.UserType{
 		UserLastModifiedDate: aws.Time(time.Now()),

--- a/pkg/adapter/common/health/health.go
+++ b/pkg/adapter/common/health/health.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package health contains helpers to enable HTTP health checking.
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"knative.dev/pkg/logging"
+)
+
+const healthPath = "/health"
+
+// Use a var instead of a const to allow tests to override this value.
+var healthPort uint16 = 8080
+
+const gracefulHandlerShutdown = 3 * time.Second
+
+// handler serves requests to the health endpoint. It returns a success HTTP
+// code when its value is true.
+type handler struct {
+	sync.RWMutex
+	ready bool
+}
+
+// Verify that handler implements http.Handler.
+var _ http.Handler = (*handler)(nil)
+
+// ServeHTTP implements http.Handler.
+func (h *handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if !h.isReady() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handler) isReady() bool {
+	h.RLock()
+	defer h.RUnlock()
+
+	return h.ready
+}
+
+var defaultHandler handler
+
+// Start runs the default HTTP health handler.
+func Start(ctx context.Context) {
+	mux := &http.ServeMux{}
+	mux.Handle(healthPath, &defaultHandler)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", healthPort),
+		Handler: mux,
+	}
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	handleServerError := func(err error) {
+		if err != http.ErrServerClosed {
+			logging.FromContext(ctx).Errorw("Error during runtime of health server", zap.Error(err))
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		ctx, cancel := context.WithTimeout(context.Background(), gracefulHandlerShutdown)
+		defer cancel()
+
+		if err := server.Shutdown(ctx); err != nil {
+			logging.FromContext(ctx).Errorw("Error during shutdown of health server", zap.Error(err))
+		}
+
+		handleServerError(<-errCh)
+
+	case err := <-errCh:
+		handleServerError(err)
+	}
+}
+
+// MarkReady indicates that the application is ready to operate.
+func MarkReady() {
+	if defaultHandler.isReady() {
+		return
+	}
+
+	defaultHandler.Lock()
+	defer defaultHandler.Unlock()
+
+	// double-checked lock to ensure we don't write the value of "ready"
+	// twice if multiple goroutines called MarkReady() simultaneously.
+	if defaultHandler.ready {
+		return
+	}
+
+	defaultHandler.ready = true
+}

--- a/pkg/adapter/common/health/health_test.go
+++ b/pkg/adapter/common/health/health_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestHandler(t *testing.T) {
+	currentHealthPort := healthPort
+	defer func() {
+		// reset port and handler state for other tests, or in case
+		// this test is executed multiple times with -count
+		healthPort = currentHealthPort
+		defaultHandler = handler{}
+	}()
+
+	healthPort = getAvailablePort(t)
+	healthURL := fmt.Sprintf("http://:%d%s", healthPort, healthPath)
+
+	ctx, cancel := context.WithCancel(logtesting.TestContextWithLogger(t))
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Start(ctx)
+		done <- struct{}{}
+	}()
+
+	// the server may need some time before it can serve the first request
+	pollURL(t, healthURL)
+
+	// not ready - expect HTTP error
+	resp, err := http.Get(healthURL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	resp.Body.Close()
+
+	MarkReady()
+
+	// ready - expect HTTP success
+	resp, err = http.Get(healthURL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	cancel()
+	<-done
+}
+
+// getFreePort returns a TCP port that's guaranteed to be currently available
+// on the local host.
+func getAvailablePort(t *testing.T) uint16 {
+	t.Helper()
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal("Failed to obtain a new Listener:", err)
+	}
+
+	defer l.Close()
+
+	return uint16(l.Addr().(*net.TCPAddr).Port)
+}
+
+// pollURL polls the given URL until a HTTP response is received.
+func pollURL(t *testing.T, url string) {
+	t.Helper()
+
+	var pollErr error
+
+	for i := 0; i < 10; i++ {
+		_, pollErr = http.Get(url)
+		if pollErr == nil {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("Health server didn't start. Last client error:", pollErr)
+}

--- a/pkg/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/reconciler/awscognitouserpoolsource/adapter.go
@@ -37,6 +37,8 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
+const healthPortName = "health"
+
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoUserPoolSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
@@ -73,6 +75,9 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoUserPoolSource, cfg *adapt
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
+
+			resource.Port(healthPortName, 8080),
+			resource.Probe("/health", healthPortName),
 		)
 	}
 }

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -38,6 +38,8 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
+const healthPortName = "health"
+
 // adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
 // given source object and adapter config.
 func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
@@ -75,7 +77,10 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 
+			resource.Port(healthPortName, 8080),
 			resource.Port("metrics", 9090),
+
+			resource.Probe("/health", healthPortName),
 
 			// CPU throttling can be observed below a limit of 1,
 			// although the CPU usage under load remains below 400m.

--- a/pkg/reconciler/common/resource/container.go
+++ b/pkg/reconciler/common/resource/container.go
@@ -163,6 +163,34 @@ func Probe(path, port string) ObjectOption {
 					Port: intstrPort,
 				},
 			},
+			// TODO(antoineco): remove delay after switching to StartupProbe, which is enabled by default
+			// starting with Kubernetes 1.18.
+			// Ref. https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+			InitialDelaySeconds: 2,
+		}
+	}
+}
+
+// StartupProbe sets the HTTP startup probe of a Deployment's first container.
+func StartupProbe(path, port string) ObjectOption {
+	return func(object interface{}) {
+		var sp **corev1.Probe
+
+		switch o := object.(type) {
+		case *corev1.Container:
+			sp = &o.StartupProbe
+		case *appsv1.Deployment:
+			sp = &firstContainer(o).StartupProbe
+		}
+
+		*sp = &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: path,
+					Port: intstr.FromString(port),
+				},
+			},
+			PeriodSeconds: 1,
 		}
 	}
 }

--- a/pkg/reconciler/common/resource/container_test.go
+++ b/pkg/reconciler/common/resource/container_test.go
@@ -35,6 +35,7 @@ func TestNewContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Probe("/health", "health"),
+		StartupProbe("/initialized", "health"),
 		EnvVarFromSecret("TEST_ENV3", "test-secret", "someKey"),
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
@@ -80,6 +81,16 @@ func TestNewContainer(t *testing.T) {
 					Port: intstr.FromString("health"),
 				},
 			},
+			InitialDelaySeconds: 2,
+		},
+		StartupProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/initialized",
+					Port: intstr.FromString("health"),
+				},
+			},
+			PeriodSeconds: 1,
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/pkg/reconciler/common/resource/deployment_test.go
+++ b/pkg/reconciler/common/resource/deployment_test.go
@@ -40,6 +40,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		Port("health", 8081),
 		Label("test.label/1", "val1"),
 		Probe("/health", "health"),
+		StartupProbe("/initialized", "health"),
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
@@ -103,6 +104,16 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 									Port: intstr.FromString("health"),
 								},
 							},
+							InitialDelaySeconds: 2,
+						},
+						StartupProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/initialized",
+									Port: intstr.FromString("health"),
+								},
+							},
+							PeriodSeconds: 1,
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/pkg/reconciler/common/resource/knservice_test.go
+++ b/pkg/reconciler/common/resource/knservice_test.go
@@ -91,6 +91,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 											Path: "/health",
 										},
 									},
+									InitialDelaySeconds: 2,
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/test/fixtures/deployment.json
+++ b/test/fixtures/deployment.json
@@ -120,7 +120,39 @@
                         "image": "gcr.io/triggermesh/awscodecommitsource",
                         "imagePullPolicy": "Always",
                         "name": "adapter",
-                        "resources": {},
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "health",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9090,
+                                "name": "metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/health",
+                                "port": "health",
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "45Mi"
+                            },
+                            "requests": {
+                                "cpu": "90m",
+                                "memory": "30Mi"
+                            }
+                        },
                         "terminationMessagePath": "/dev/termination-log",
                         "terminationMessagePolicy": "File"
                     }


### PR DESCRIPTION
Adds a helper that starts a health probe handler on `:8080/health` and allows the caller to decide when the endpoint should report success by calling the `MarkReady()` function.

It's really trivial and doesn't do any magic, such as rechecking AWS regularly. It is simply meant to delay readiness until we have ensured AWS is actually reachable with the secret access key provided by the user, and therefore eliminate some flakiness with timing-sensitive consumers (like e2e tests).

Currently implemented in the SQS and Cognito adapters only.

Closes #244 