### PR TITLE
Add reconciler tests for SNS' ensureSubscribe and ensureUnsubscribe

### DIFF
--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -97,14 +97,17 @@ var awsSNSSourceConditionSet = NewEventSourceConditionSet(
 	AWSSNSConditionSubscribed,
 )
 
-// MarkSubscribed sets the Subscribed condition to True.
-func (s *AWSSNSSourceStatus) MarkSubscribed() {
+// MarkSubscribed sets the Subscribed condition to True and reports the ARN of
+// the SNS subscription.
+func (s *AWSSNSSourceStatus) MarkSubscribed(subARN string) {
+	s.SubscriptionARN = &subARN
 	awsSNSSourceConditionSet.Manage(s).MarkTrue(AWSSNSConditionSubscribed)
 }
 
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and associated message.
 func (s *AWSSNSSourceStatus) MarkNotSubscribed(reason, msg string) {
+	s.SubscriptionARN = nil
 	awsSNSSourceConditionSet.Manage(s).MarkFalse(AWSSNSConditionSubscribed,
 		reason, msg)
 }

--- a/pkg/reconciler/awscloudwatchlogssource/reconciler_test.go
+++ b/pkg/reconciler/awscloudwatchlogssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis"
@@ -57,7 +58,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSCloudWatchLogsSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awscloudwatchsource/reconciler_test.go
+++ b/pkg/reconciler/awscloudwatchsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,10 +23,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis"
@@ -54,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSCloudWatchSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awscodecommitsource/reconciler_test.go
+++ b/pkg/reconciler/awscodecommitsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSCodeCommitSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awscognitoidentitysource/reconciler_test.go
+++ b/pkg/reconciler/awscognitoidentitysource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSCognitoIdentitySource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awscognitouserpoolsource/reconciler_test.go
+++ b/pkg/reconciler/awscognitouserpoolsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSCognitoUserPoolSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSDynamoDBSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awsiotsource/reconciler_test.go
+++ b/pkg/reconciler/awsiotsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -65,7 +66,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSIoTSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/reconciler/awskinesissource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSKinesisSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/awssnssource/client.go
+++ b/pkg/reconciler/awssnssource/client.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssnssource
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+)
+
+// Client is an alias for the SNSAPI interface.
+type Client = snsiface.SNSAPI
+
+// ClientGetter can obtain SNS clients.
+type ClientGetter interface {
+	Get(*v1alpha1.AWSSNSSource) (Client, error)
+}
+
+// newClientGetter returns a ClientGetter for the given namespacedSecretsGetter.
+func newClientGetter(sg namespacedSecretsGetter) *clientGetterWithSecretGetter {
+	return &clientGetterWithSecretGetter{
+		sg: sg,
+	}
+}
+
+type namespacedSecretsGetter func(namespace string) coreclientv1.SecretInterface
+
+// clientGetterWithSecretGetter gets SNS clients using static credentials
+// retrieved using a Secret getter.
+type clientGetterWithSecretGetter struct {
+	sg namespacedSecretsGetter
+}
+
+// clientGetterWithSecretGetter implements ClientGetter.
+var _ ClientGetter = (*clientGetterWithSecretGetter)(nil)
+
+// Get implements ClientGetter.
+func (g *clientGetterWithSecretGetter) Get(src *v1alpha1.AWSSNSSource) (Client, error) {
+	creds, err := g.awsCredentials(src.Namespace, &src.Spec.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving AWS security credentials: %w", err)
+	}
+
+	return sns.New(session.Must(session.NewSession(aws.NewConfig().
+		WithRegion(src.Spec.ARN.Region).
+		WithCredentials(credentials.NewStaticCredentialsFromCreds(*creds)),
+	))), nil
+}
+
+// awsCredentials returns the AWS security credentials referenced in a source's
+// spec, using the ClientGetter's Secrets getter if necessary.
+func (g *clientGetterWithSecretGetter) awsCredentials(namespace string,
+	creds *v1alpha1.AWSSecurityCredentials) (*credentials.Value, error) {
+
+	accessKeyID := creds.AccessKeyID.Value
+	secretAccessKey := creds.SecretAccessKey.Value
+
+	cli := g.sg(namespace)
+
+	// cache a Secret object by name to avoid GET-ing the same Secret
+	// object multiple times
+	var secretCache map[string]*corev1.Secret
+
+	if vfs := creds.AccessKeyID.ValueFromSecret; vfs != nil {
+		secr, err := cli.Get(context.Background(), vfs.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("getting Secret from cluster: %w", err)
+		}
+
+		// cache Secret containing the access key ID so it can be reused
+		// below in case the same Secret contains the secret access key
+		secretCache = map[string]*corev1.Secret{
+			vfs.Name: secr,
+		}
+
+		accessKeyID = string(secr.Data[vfs.Key])
+	}
+
+	if vfs := creds.SecretAccessKey.ValueFromSecret; vfs != nil {
+		var secr *corev1.Secret
+		var err error
+
+		if secretCache != nil && secretCache[vfs.Name] != nil {
+			secr = secretCache[vfs.Name]
+		} else {
+			secr, err = cli.Get(context.Background(), vfs.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("getting Secret from cluster: %w", err)
+			}
+		}
+
+		secretAccessKey = string(secr.Data[vfs.Key])
+	}
+
+	return &credentials.Value{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+	}, nil
+}
+
+// clientGetterFunc allows the use of ordinary functions as ClientGetter.
+type clientGetterFunc func(*v1alpha1.AWSSNSSource) (Client, error)
+
+// clientGetterFunc implements ClientGetter.
+var _ ClientGetter = (clientGetterFunc)(nil)
+
+// Get implements ClientGetter.
+func (f clientGetterFunc) Get(src *v1alpha1.AWSSNSSource) (Client, error) {
+	return f(src)
+}

--- a/pkg/reconciler/awssnssource/client_test.go
+++ b/pkg/reconciler/awssnssource/client_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssnssource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+)
+
+func TestAwsCredentials(t *testing.T) {
+	const (
+		ns = "fake-namespace"
+
+		accessKeyIDKey     = "key-id"
+		accessKeyIDVal     = "fake key ID"
+		secretAccessKeyKey = "secret-key"
+		secretAccessKeyVal = "fake secret"
+	)
+
+	testCases := []struct {
+		name        string
+		initSecrets []*corev1.Secret
+		input       v1alpha1.AWSSecurityCredentials
+		expect      *credentials.Value
+		getRequests int
+	}{
+		{
+			name: "Both from value",
+			input: v1alpha1.AWSSecurityCredentials{
+				AccessKeyID: v1alpha1.ValueFromField{
+					Value: accessKeyIDVal,
+				},
+				SecretAccessKey: v1alpha1.ValueFromField{
+					Value: secretAccessKeyVal,
+				},
+			},
+			expect: &credentials.Value{
+				AccessKeyID:     accessKeyIDVal,
+				SecretAccessKey: secretAccessKeyVal,
+			},
+			getRequests: 0,
+		},
+		{
+			name: "One from value, the other from secret",
+			initSecrets: []*corev1.Secret{
+				newSecret(ns, "secret1", map[string]string{
+					secretAccessKeyKey: secretAccessKeyVal,
+				}),
+			},
+			input: v1alpha1.AWSSecurityCredentials{
+				AccessKeyID: v1alpha1.ValueFromField{
+					Value: accessKeyIDVal,
+				},
+				SecretAccessKey: v1alpha1.ValueFromField{
+					ValueFromSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "secret1",
+						},
+						Key: secretAccessKeyKey,
+					},
+				},
+			},
+			expect: &credentials.Value{
+				AccessKeyID:     accessKeyIDVal,
+				SecretAccessKey: secretAccessKeyVal,
+			},
+			getRequests: 1,
+		},
+		{
+			name: "Both from same secret",
+			initSecrets: []*corev1.Secret{
+				newSecret(ns, "secret1", map[string]string{
+					accessKeyIDKey:     accessKeyIDVal,
+					secretAccessKeyKey: secretAccessKeyVal,
+				}),
+			},
+			input: v1alpha1.AWSSecurityCredentials{
+				AccessKeyID: v1alpha1.ValueFromField{
+					ValueFromSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "secret1",
+						},
+						Key: accessKeyIDKey,
+					},
+				},
+				SecretAccessKey: v1alpha1.ValueFromField{
+					ValueFromSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "secret1",
+						},
+						Key: secretAccessKeyKey,
+					},
+				},
+			},
+			expect: &credentials.Value{
+				AccessKeyID:     accessKeyIDVal,
+				SecretAccessKey: secretAccessKeyVal,
+			},
+			getRequests: 1,
+		},
+		{
+			name: "Both from different secrets",
+			initSecrets: []*corev1.Secret{
+				newSecret(ns, "secret1", map[string]string{
+					accessKeyIDKey: accessKeyIDVal,
+				}),
+				newSecret(ns, "secret2", map[string]string{
+					secretAccessKeyKey: secretAccessKeyVal,
+				}),
+			},
+			input: v1alpha1.AWSSecurityCredentials{
+				AccessKeyID: v1alpha1.ValueFromField{
+					ValueFromSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "secret1",
+						},
+						Key: accessKeyIDKey,
+					},
+				},
+				SecretAccessKey: v1alpha1.ValueFromField{
+					ValueFromSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "secret2",
+						},
+						Key: secretAccessKeyKey,
+					},
+				},
+			},
+			expect: &credentials.Value{
+				AccessKeyID:     accessKeyIDVal,
+				SecretAccessKey: secretAccessKeyVal,
+			},
+			getRequests: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		//nolint:scopelint
+		t.Run(tc.name, func(t *testing.T) {
+			secrets := make([]runtime.Object, len(tc.initSecrets))
+			for i, secret := range tc.initSecrets {
+				secrets[i] = secret
+			}
+
+			cli := fake.NewSimpleClientset(secrets...)
+
+			cg := newClientGetter(cli.CoreV1().Secrets)
+			creds, err := cg.awsCredentials(ns, &tc.input)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expect.AccessKeyID, creds.AccessKeyID, "Value of access key ID")
+			assert.Equal(t, tc.expect.SecretAccessKey, creds.SecretAccessKey, "Value of secret access key")
+			assert.Equal(t, tc.getRequests, len(cli.Actions()), "Number of API requests")
+		})
+	}
+}
+
+func newSecret(ns, name string, data map[string]string) *corev1.Secret {
+	secr := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Data: make(map[string][]byte, len(data)),
+	}
+
+	for k, v := range data {
+		secr.Data[k] = []byte(v)
+	}
+
+	return secr
+}

--- a/pkg/reconciler/awssnssource/controller.go
+++ b/pkg/reconciler/awssnssource/controller.go
@@ -54,7 +54,7 @@ func NewController(
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
-		secretsCli: k8sclient.Get(ctx).CoreV1().Secrets,
+		snsCg:      newClientGetter(k8sclient.Get(ctx).CoreV1().Secrets),
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 

--- a/pkg/reconciler/awssnssource/reconciler.go
+++ b/pkg/reconciler/awssnssource/reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"knative.dev/pkg/reconciler"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -33,8 +32,8 @@ type Reconciler struct {
 	base       common.GenericServiceReconciler
 	adapterCfg *adapterConfig
 
-	// API clients
-	secretsCli func(namespace string) coreclientv1.SecretInterface
+	// SNS client interface
+	snsCg ClientGetter
 }
 
 // Check that our Reconciler implements Interface

--- a/pkg/reconciler/awssnssource/reconciler.go
+++ b/pkg/reconciler/awssnssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/reconciler/awssnssource/reconciler_test.go
@@ -68,7 +68,6 @@ func reconcilerCtor(cfg *adapterConfig) Ctor {
 		r := &Reconciler{
 			base:       base,
 			adapterCfg: cfg,
-			secretsCli: fakek8sinjectionclient.Get(ctx).CoreV1().Secrets,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),

--- a/pkg/reconciler/awssnssource/subscription_test.go
+++ b/pkg/reconciler/awssnssource/subscription_test.go
@@ -61,4 +61,11 @@ func TestErrors(t *testing.T) {
 		assert.False(t, isNotFound(genericK8SErr))
 		assert.False(t, isNotFound(genericErr))
 	})
+
+	t.Run("print error", func(t *testing.T) {
+		awssErrWithExtra := awserr.NewRequestFailure(genericAWSErr, 400, "0123456789")
+
+		assert.Equal(t, genericAWSErr.Error(), toErrMsg(awssErrWithExtra), "Extras not trimmed from AWS error")
+		assert.Equal(t, genericErr.Error(), toErrMsg(genericErr), "Error was altered")
+	})
 }

--- a/pkg/reconciler/awssnssource/subscription_test.go
+++ b/pkg/reconciler/awssnssource/subscription_test.go
@@ -21,168 +21,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/sns"
-
-	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
-
-func TestAwsCredentials(t *testing.T) {
-	const (
-		ns = "fake-namespace"
-
-		accessKeyIDKey     = "key-id"
-		accessKeyIDVal     = "fake key ID"
-		secretAccessKeyKey = "secret-key"
-		secretAccessKeyVal = "fake secret"
-	)
-
-	testCases := []struct {
-		name        string
-		initSecrets []*corev1.Secret
-		input       v1alpha1.AWSSecurityCredentials
-		expect      *credentials.Value
-		getRequests int
-	}{
-		{
-			name: "Both from value",
-			input: v1alpha1.AWSSecurityCredentials{
-				AccessKeyID: v1alpha1.ValueFromField{
-					Value: accessKeyIDVal,
-				},
-				SecretAccessKey: v1alpha1.ValueFromField{
-					Value: secretAccessKeyVal,
-				},
-			},
-			expect: &credentials.Value{
-				AccessKeyID:     accessKeyIDVal,
-				SecretAccessKey: secretAccessKeyVal,
-			},
-			getRequests: 0,
-		},
-		{
-			name: "One from value, the other from secret",
-			initSecrets: []*corev1.Secret{
-				newSecret(ns, "secret1", map[string]string{
-					secretAccessKeyKey: secretAccessKeyVal,
-				}),
-			},
-			input: v1alpha1.AWSSecurityCredentials{
-				AccessKeyID: v1alpha1.ValueFromField{
-					Value: accessKeyIDVal,
-				},
-				SecretAccessKey: v1alpha1.ValueFromField{
-					ValueFromSecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "secret1",
-						},
-						Key: secretAccessKeyKey,
-					},
-				},
-			},
-			expect: &credentials.Value{
-				AccessKeyID:     accessKeyIDVal,
-				SecretAccessKey: secretAccessKeyVal,
-			},
-			getRequests: 1,
-		},
-		{
-			name: "Both from same secret",
-			initSecrets: []*corev1.Secret{
-				newSecret(ns, "secret1", map[string]string{
-					accessKeyIDKey:     accessKeyIDVal,
-					secretAccessKeyKey: secretAccessKeyVal,
-				}),
-			},
-			input: v1alpha1.AWSSecurityCredentials{
-				AccessKeyID: v1alpha1.ValueFromField{
-					ValueFromSecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "secret1",
-						},
-						Key: accessKeyIDKey,
-					},
-				},
-				SecretAccessKey: v1alpha1.ValueFromField{
-					ValueFromSecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "secret1",
-						},
-						Key: secretAccessKeyKey,
-					},
-				},
-			},
-			expect: &credentials.Value{
-				AccessKeyID:     accessKeyIDVal,
-				SecretAccessKey: secretAccessKeyVal,
-			},
-			getRequests: 1,
-		},
-		{
-			name: "Both from a different secret",
-			initSecrets: []*corev1.Secret{
-				newSecret(ns, "secret1", map[string]string{
-					accessKeyIDKey: accessKeyIDVal,
-				}),
-				newSecret(ns, "secret2", map[string]string{
-					secretAccessKeyKey: secretAccessKeyVal,
-				}),
-			},
-			input: v1alpha1.AWSSecurityCredentials{
-				AccessKeyID: v1alpha1.ValueFromField{
-					ValueFromSecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "secret1",
-						},
-						Key: accessKeyIDKey,
-					},
-				},
-				SecretAccessKey: v1alpha1.ValueFromField{
-					ValueFromSecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "secret2",
-						},
-						Key: secretAccessKeyKey,
-					},
-				},
-			},
-			expect: &credentials.Value{
-				AccessKeyID:     accessKeyIDVal,
-				SecretAccessKey: secretAccessKeyVal,
-			},
-			getRequests: 2,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			secrets := make([]runtime.Object, len(tc.initSecrets))
-			for i, secret := range tc.initSecrets {
-				secrets[i] = secret
-			}
-
-			cli := fake.NewSimpleClientset(secrets...)
-
-			creds, err := awsCredentials(cli.CoreV1().Secrets(ns), &tc.input)
-
-			require.NoError(t, err)
-
-			assert.Equal(t, tc.expect.AccessKeyID, creds.AccessKeyID, "Value of access key ID")
-			assert.Equal(t, tc.expect.SecretAccessKey, creds.SecretAccessKey, "Value of secret access key")
-			assert.Equal(t, tc.getRequests, len(cli.Actions()), "Number of API requests")
-		})
-	}
-}
 
 func TestErrors(t *testing.T) {
 	genericErr := assert.AnError
@@ -216,20 +61,4 @@ func TestErrors(t *testing.T) {
 		assert.False(t, isNotFound(genericK8SErr))
 		assert.False(t, isNotFound(genericErr))
 	})
-}
-
-func newSecret(ns, name string, data map[string]string) *corev1.Secret {
-	secr := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Data: make(map[string][]byte, len(data)),
-	}
-
-	for k, v := range data {
-		secr.Data[k] = []byte(v)
-	}
-
-	return secr
 }

--- a/pkg/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/reconciler/awssqssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	rt "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -55,7 +56,7 @@ func TestReconcileSource(t *testing.T) {
 
 // reconcilerCtor returns a Ctor for a AWSSQSSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		base := common.GenericDeploymentReconciler{
 			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			Lister:       ls.GetDeploymentLister().Deployments,

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import (
 )
 
 // Ctor constructs a controller.Reconciler.
-type Ctor func(*testing.T, context.Context, *Listers) controller.Reconciler
+type Ctor func(*testing.T, context.Context, *rt.TableRow, *Listers) controller.Reconciler
 
 // MakeFactory creates a testing factory for our controller.Reconciler, and
 // initializes a Reconciler using the given Ctor as part of the process.
@@ -78,7 +78,7 @@ func MakeFactory(ctor Ctor) rt.Factory {
 		ctx = controller.WithEventRecorder(ctx, eventRecorder)
 
 		// set up Reconciler from fakes
-		r := ctor(t, ctx, &ls)
+		r := ctor(t, ctx, tr, &ls)
 
 		// promote the reconciler if it is leader aware
 		if la, ok := r.(reconciler.LeaderAware); ok {


### PR DESCRIPTION
Closes #248

Brings the code coverage from 36.1% to 76.4%.