### PR TITLE
Add JSON schemas for emitted event types

### DIFF
--- a/schemas/com.amazon.cloudwatch.metrics.message.json
+++ b/schemas/com.amazon.cloudwatch.metrics.message.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/MessageData",
+  "definitions": {
+    "MessageData": {
+      "required": [
+        "Code",
+        "Value"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.cloudwatch.metrics.metric.json
+++ b/schemas/com.amazon.cloudwatch.metrics.metric.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/MetricDataResult",
+  "definitions": {
+    "MessageData": {
+      "required": [
+        "Code",
+        "Value"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricDataResult": {
+      "required": [
+        "Id",
+        "Label",
+        "Messages",
+        "StatusCode",
+        "Timestamps",
+        "Values"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string"
+        },
+        "Label": {
+          "type": "string"
+        },
+        "Messages": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/MessageData"
+          },
+          "type": "array"
+        },
+        "StatusCode": {
+          "type": "string"
+        },
+        "Timestamps": {
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": "array"
+        },
+        "Values": {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.codecommit.pull_request.json
+++ b/schemas/com.amazon.codecommit.pull_request.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/PullRequest",
+  "definitions": {
+    "ApprovalRule": {
+      "required": [
+        "ApprovalRuleContent",
+        "ApprovalRuleId",
+        "ApprovalRuleName",
+        "CreationDate",
+        "LastModifiedDate",
+        "LastModifiedUser",
+        "OriginApprovalRuleTemplate",
+        "RuleContentSha256"
+      ],
+      "properties": {
+        "ApprovalRuleContent": {
+          "type": "string"
+        },
+        "ApprovalRuleId": {
+          "type": "string"
+        },
+        "ApprovalRuleName": {
+          "type": "string"
+        },
+        "CreationDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "LastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "LastModifiedUser": {
+          "type": "string"
+        },
+        "OriginApprovalRuleTemplate": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/OriginApprovalRuleTemplate"
+        },
+        "RuleContentSha256": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MergeMetadata": {
+      "required": [
+        "IsMerged",
+        "MergeCommitId",
+        "MergeOption",
+        "MergedBy"
+      ],
+      "properties": {
+        "IsMerged": {
+          "type": "boolean"
+        },
+        "MergeCommitId": {
+          "type": "string"
+        },
+        "MergeOption": {
+          "type": "string"
+        },
+        "MergedBy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "OriginApprovalRuleTemplate": {
+      "required": [
+        "ApprovalRuleTemplateId",
+        "ApprovalRuleTemplateName"
+      ],
+      "properties": {
+        "ApprovalRuleTemplateId": {
+          "type": "string"
+        },
+        "ApprovalRuleTemplateName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PullRequest": {
+      "required": [
+        "ApprovalRules",
+        "AuthorArn",
+        "ClientRequestToken",
+        "CreationDate",
+        "Description",
+        "LastActivityDate",
+        "PullRequestId",
+        "PullRequestStatus",
+        "PullRequestTargets",
+        "RevisionId",
+        "Title"
+      ],
+      "properties": {
+        "ApprovalRules": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/ApprovalRule"
+          },
+          "type": "array"
+        },
+        "AuthorArn": {
+          "type": "string"
+        },
+        "ClientRequestToken": {
+          "type": "string"
+        },
+        "CreationDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "LastActivityDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "PullRequestId": {
+          "type": "string"
+        },
+        "PullRequestStatus": {
+          "type": "string"
+        },
+        "PullRequestTargets": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/PullRequestTarget"
+          },
+          "type": "array"
+        },
+        "RevisionId": {
+          "type": "string"
+        },
+        "Title": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PullRequestTarget": {
+      "required": [
+        "DestinationCommit",
+        "DestinationReference",
+        "MergeBase",
+        "MergeMetadata",
+        "RepositoryName",
+        "SourceCommit",
+        "SourceReference"
+      ],
+      "properties": {
+        "DestinationCommit": {
+          "type": "string"
+        },
+        "DestinationReference": {
+          "type": "string"
+        },
+        "MergeBase": {
+          "type": "string"
+        },
+        "MergeMetadata": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/MergeMetadata"
+        },
+        "RepositoryName": {
+          "type": "string"
+        },
+        "SourceCommit": {
+          "type": "string"
+        },
+        "SourceReference": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.codecommit.push.json
+++ b/schemas/com.amazon.codecommit.push.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Commit",
+  "definitions": {
+    "Commit": {
+      "required": [
+        "AdditionalData",
+        "Author",
+        "CommitId",
+        "Committer",
+        "Message",
+        "Parents",
+        "TreeId"
+      ],
+      "properties": {
+        "AdditionalData": {
+          "type": "string"
+        },
+        "Author": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/UserInfo"
+        },
+        "CommitId": {
+          "type": "string"
+        },
+        "Committer": {
+          "$ref": "#/definitions/UserInfo"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Parents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "TreeId": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "UserInfo": {
+      "required": [
+        "Date",
+        "Email",
+        "Name"
+      ],
+      "properties": {
+        "Date": {
+          "type": "string"
+        },
+        "Email": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.cognito-identity.sync_trigger.json
+++ b/schemas/com.amazon.cognito-identity.sync_trigger.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/CognitoIdentitySyncEvent",
+  "definitions": {
+    "CognitoIdentitySyncEvent": {
+      "required": [
+        "CreationDate",
+        "DataStorage",
+        "DatasetName",
+        "IdentityID",
+        "LastModifiedBy",
+        "LastModifiedDate",
+        "NumRecords",
+        "EventType",
+        "Region",
+        "IdentityPoolID",
+        "DatasetRecords"
+      ],
+      "properties": {
+        "CreationDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "DataStorage": {
+          "type": "integer"
+        },
+        "DatasetName": {
+          "type": "string"
+        },
+        "DatasetRecords": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/Record"
+          },
+          "type": "array"
+        },
+        "EventType": {
+          "type": "string"
+        },
+        "IdentityID": {
+          "type": "string"
+        },
+        "IdentityPoolID": {
+          "type": "string"
+        },
+        "LastModifiedBy": {
+          "type": "string"
+        },
+        "LastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "NumRecords": {
+          "type": "integer"
+        },
+        "Region": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Record": {
+      "required": [
+        "DeviceLastModifiedDate",
+        "Key",
+        "LastModifiedBy",
+        "LastModifiedDate",
+        "SyncCount",
+        "Value"
+      ],
+      "properties": {
+        "DeviceLastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Key": {
+          "type": "string"
+        },
+        "LastModifiedBy": {
+          "type": "string"
+        },
+        "LastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "SyncCount": {
+          "type": "integer"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.cognitouserpool.sync_trigger.json
+++ b/schemas/com.amazon.cognitouserpool.sync_trigger.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/UserType",
+  "definitions": {
+    "AttributeType": {
+      "required": [
+        "Name",
+        "Value"
+      ],
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MFAOptionType": {
+      "required": [
+        "AttributeName",
+        "DeliveryMedium"
+      ],
+      "properties": {
+        "AttributeName": {
+          "type": "string"
+        },
+        "DeliveryMedium": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "UserType": {
+      "required": [
+        "Attributes",
+        "Enabled",
+        "MFAOptions",
+        "UserCreateDate",
+        "UserLastModifiedDate",
+        "UserStatus",
+        "Username"
+      ],
+      "properties": {
+        "Attributes": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/AttributeType"
+          },
+          "type": "array"
+        },
+        "Enabled": {
+          "type": "boolean"
+        },
+        "MFAOptions": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/MFAOptionType"
+          },
+          "type": "array"
+        },
+        "UserCreateDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "UserLastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "UserStatus": {
+          "type": "string"
+        },
+        "Username": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.dynamodb.record.json
+++ b/schemas/com.amazon.dynamodb.record.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Record",
+  "definitions": {
+    "AttributeValue": {
+      "required": [
+        "B",
+        "BOOL",
+        "BS",
+        "L",
+        "M",
+        "N",
+        "NS",
+        "NULL",
+        "S",
+        "SS"
+      ],
+      "properties": {
+        "B": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "BOOL": {
+          "type": "boolean"
+        },
+        "BS": {
+          "items": {
+            "type": "string",
+            "media": {
+              "binaryEncoding": "base64"
+            }
+          },
+          "type": "array"
+        },
+        "L": {
+          "items": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "type": "array"
+        },
+        "M": {
+          "patternProperties": {
+            ".*": {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          },
+          "type": "object"
+        },
+        "N": {
+          "type": "string"
+        },
+        "NS": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "NULL": {
+          "type": "boolean"
+        },
+        "S": {
+          "type": "string"
+        },
+        "SS": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Identity": {
+      "required": [
+        "PrincipalId",
+        "Type"
+      ],
+      "properties": {
+        "PrincipalId": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Record": {
+      "required": [
+        "AwsRegion",
+        "Dynamodb",
+        "EventID",
+        "EventName",
+        "EventSource",
+        "EventVersion",
+        "UserIdentity"
+      ],
+      "properties": {
+        "AwsRegion": {
+          "type": "string"
+        },
+        "Dynamodb": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/StreamRecord"
+        },
+        "EventID": {
+          "type": "string"
+        },
+        "EventName": {
+          "type": "string"
+        },
+        "EventSource": {
+          "type": "string"
+        },
+        "EventVersion": {
+          "type": "string"
+        },
+        "UserIdentity": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/Identity"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StreamRecord": {
+      "required": [
+        "ApproximateCreationDateTime",
+        "Keys",
+        "NewImage",
+        "OldImage",
+        "SequenceNumber",
+        "SizeBytes",
+        "StreamViewType"
+      ],
+      "properties": {
+        "ApproximateCreationDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Keys": {
+          "patternProperties": {
+            ".*": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$ref": "#/definitions/AttributeValue"
+            }
+          },
+          "type": "object"
+        },
+        "NewImage": {
+          "patternProperties": {
+            ".*": {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          },
+          "type": "object"
+        },
+        "OldImage": {
+          "patternProperties": {
+            ".*": {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          },
+          "type": "object"
+        },
+        "SequenceNumber": {
+          "type": "string"
+        },
+        "SizeBytes": {
+          "type": "integer"
+        },
+        "StreamViewType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.kinesis.stream_record.json
+++ b/schemas/com.amazon.kinesis.stream_record.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Record",
+  "definitions": {
+    "Record": {
+      "required": [
+        "ApproximateArrivalTimestamp",
+        "Data",
+        "EncryptionType",
+        "PartitionKey",
+        "SequenceNumber"
+      ],
+      "properties": {
+        "ApproximateArrivalTimestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Data": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "EncryptionType": {
+          "type": "string"
+        },
+        "PartitionKey": {
+          "type": "string"
+        },
+        "SequenceNumber": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.logs.log.json
+++ b/schemas/com.amazon.logs.log.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/OutputLogEvent",
+  "definitions": {
+    "OutputLogEvent": {
+      "required": [
+        "IngestionTime",
+        "Message",
+        "Timestamp"
+      ],
+      "properties": {
+        "IngestionTime": {
+          "type": "integer"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Timestamp": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.sns.notification.json
+++ b/schemas/com.amazon.sns.notification.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/MessageData",
+  "definitions": {
+    "MessageData": {
+      "required": [
+        "Type",
+        "MessageId",
+        "TopicArn",
+        "Message",
+        "Timestamp",
+        "SignatureVersion",
+        "Signature",
+        "SigningCertURL",
+        "UnsubscribeURL"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Notification"
+          ]
+        },
+        "MessageId": {
+          "type": "string"
+        },
+        "TopicArn": {
+          "type": "string"
+        },
+        "Subject": {
+          "type": "string"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "SignatureVersion": {
+          "type": "string"
+        },
+        "Signature": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "SigningCertURL": {
+          "type": "string",
+          "format": "uri"
+        },
+        "UnsubscribeURL": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemas/com.amazon.sqs.message.json
+++ b/schemas/com.amazon.sqs.message.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Message",
+  "definitions": {
+    "Message": {
+      "required": [
+        "Attributes",
+        "Body",
+        "MD5OfBody",
+        "MD5OfMessageAttributes",
+        "MessageAttributes",
+        "MessageId",
+        "ReceiptHandle"
+      ],
+      "properties": {
+        "Attributes": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Body": {
+          "type": "string"
+        },
+        "MD5OfBody": {
+          "type": "string"
+        },
+        "MD5OfMessageAttributes": {
+          "type": "string"
+        },
+        "MessageAttributes": {
+          "patternProperties": {
+            ".*": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$ref": "#/definitions/MessageAttributeValue"
+            }
+          },
+          "type": "object"
+        },
+        "MessageId": {
+          "type": "string"
+        },
+        "ReceiptHandle": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MessageAttributeValue": {
+      "required": [
+        "BinaryListValues",
+        "BinaryValue",
+        "DataType",
+        "StringListValues",
+        "StringValue"
+      ],
+      "properties": {
+        "BinaryListValues": {
+          "items": {
+            "type": "string",
+            "media": {
+              "binaryEncoding": "base64"
+            }
+          },
+          "type": "array"
+        },
+        "BinaryValue": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "DataType": {
+          "type": "string"
+        },
+        "StringListValues": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "StringValue": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
For unmodified exported type, the following program was used to generate schemas:

```go
package main

import (
        "encoding/json"
        "fmt"

        "github.com/alecthomas/jsonschema"
)

func main() {
        typ := // the type to generate a schema for

        schema := jsonschema.Reflect(typ)

        b, err := json.MarshalIndent(schema, "", "  ")
        if err != nil {
                panic(fmt.Errorf("marshaling schema: %w", err))
        }

        fmt.Print(string(b), "\n")
}
```

Others, like `com.amazon.sns.notification.json`, were written by hand.