### PR TITLE
Multi-tenancy: Reconcile ServiceAccount per namespace and per source kind

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -106,6 +106,48 @@ rules:
   - awssnssources
   verbs:
   - patch
+
+# Manage resource-specific ServiceAccounts and RoleBindings
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  resourceNames: &rbac-objects
+  - awscloudwatchlogssource-adapter
+  - awscloudwatchsource-adapter
+  - awscodecommitsource-adapter
+  - awscognitoidentitysource-adapter
+  - awscognitouserpoolsource-adapter
+  - awsdynamodbsource-adapter
+  - awsiotsource-adapter
+  - awskinesissource-adapter
+  - awssnssource-adapter
+  - awssqssource-adapter
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - watch
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  resourceNames: *rbac-objects
+  verbs:
+  - update
 
 # Read credentials
 - apiGroups:

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -83,6 +83,13 @@ func (m *EventSourceStatusManager) MarkNoSink() {
 	m.SinkURI = nil
 	m.ConditionSet.Manage(m).MarkFalse(ConditionSinkProvided,
 		ReasonSinkNotFound, "The sink does not exist or its URI is not set")
+}
+
+// MarkRBACNotBound sets the Deployed condition to False, indicating that the
+// adapter's ServiceAccount couldn't be bound.
+func (m *EventSourceStatusManager) MarkRBACNotBound() {
+	m.ConditionSet.Manage(m).MarkFalse(ConditionDeployed,
+		ReasonRBACNotBound, "The adapter's ServiceAccount can not be bound")
 }
 
 // PropagateDeploymentAvailability uses the readiness of the provided

--- a/pkg/apis/sources/v1alpha1/conditions.go
+++ b/pkg/apis/sources/v1alpha1/conditions.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,6 +37,9 @@ const (
 	// ReasonSinkEmpty is set on a SinkProvided condition when a sink URI is empty.
 	ReasonSinkEmpty = "EmptySinkURI"
 
+	// ReasonRBACNotBound is set on a Deployed condition when an adapter's
+	// ServiceAccount cannot be bound.
+	ReasonRBACNotBound = "RBACNotBound"
 	// ReasonUnavailable is set on a Deployed condition when an adapter in unavailable.
 	ReasonUnavailable = "AdapterUnavailable"
 )

--- a/pkg/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/reconciler/awscloudwatchlogssource/adapter.go
@@ -17,11 +17,15 @@ limitations under the License.
 package awscloudwatchlogssource
 
 import (
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -41,22 +45,39 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSCloudWatchLogsSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		pollingInterval := defaultPollingInterval
-		if f := src.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
-			pollingInterval = time.Duration(*f)
-		}
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSCloudWatchLogsSource)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVar(envPollingInterval, pollingInterval.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+	pollingInterval := defaultPollingInterval
+	if f := typedSrc.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
+		pollingInterval = time.Duration(*f)
 	}
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVar(envPollingInterval, pollingInterval.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
+	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awscloudwatchlogssource/controller.go
+++ b/pkg/reconciler/awscloudwatchlogssource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSCloudWatchLogsSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awscloudwatchlogssource/controller_test.go
+++ b/pkg/reconciler/awscloudwatchlogssource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscloudwatchlogssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awscloudwatchlogssource/reconciler.go
+++ b/pkg/reconciler/awscloudwatchlogssource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscloudwatchlogssource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSCloudWatchLogsSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSCloudWa
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/reconciler/awscloudwatchsource/adapter.go
@@ -18,11 +18,15 @@ package awscloudwatchsource
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -46,31 +50,48 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSCloudWatchSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		var queries string
-		if len(src.Spec.MetricQueries) > 0 {
-			q, _ := json.Marshal(src.Spec.MetricQueries)
-			queries = string(q)
-		}
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-		pollingInterval := defaultPollingInterval
-		if f := src.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
-			pollingInterval = time.Duration(*f)
-		}
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSCloudWatchSource)
 
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
-
-			resource.EnvVar(envRegion, src.Spec.Region),
-			resource.EnvVar(envQueries, queries),
-			resource.EnvVar(envPollingInterval, pollingInterval.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-			resource.EnvVar(common.EnvName, src.GetName()),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+	var queries string
+	if qs := typedSrc.Spec.MetricQueries; len(qs) > 0 {
+		q, _ := json.Marshal(qs)
+		queries = string(q)
 	}
+
+	pollingInterval := defaultPollingInterval
+	if f := typedSrc.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
+		pollingInterval = time.Duration(*f)
+	}
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(envRegion, typedSrc.Spec.Region),
+		resource.EnvVar(envQueries, queries),
+		resource.EnvVar(envPollingInterval, pollingInterval.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
+		resource.EnvVar(common.EnvName, src.GetName()),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
+	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/reconciler/awscloudwatchsource/adapter.go
@@ -68,6 +68,8 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSCloudWatchSource, cfg *adapterCon
 			resource.EnvVar(envQueries, queries),
 			resource.EnvVar(envPollingInterval, pollingInterval.String()),
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
+			resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
+			resource.EnvVar(common.EnvName, src.GetName()),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 		)
 	}

--- a/pkg/reconciler/awscloudwatchsource/controller.go
+++ b/pkg/reconciler/awscloudwatchsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSCloudWatchSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awscloudwatchsource/controller_test.go
+++ b/pkg/reconciler/awscloudwatchsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,12 +21,13 @@ import (
 
 	. "github.com/triggermesh/aws-event-sources/pkg/reconciler/testing"
 
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
-	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
-
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscloudwatchsource/fake"
+	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
+	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 
 func TestNewController(t *testing.T) {

--- a/pkg/reconciler/awscloudwatchsource/reconciler.go
+++ b/pkg/reconciler/awscloudwatchsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscloudwatchsource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSCloudWatchSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSCloudWa
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awscloudwatchsource/reconciler_test.go
+++ b/pkg/reconciler/awscloudwatchsource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,14 +22,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis"
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSCloudWatchSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSCloudWatchSourceLister().AWSCloudWatchSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -125,4 +114,12 @@ func newEventSource() *v1alpha1.AWSCloudWatchSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/reconciler/awscodecommitsource/adapter.go
@@ -17,12 +17,15 @@ limitations under the License.
 package awscodecommitsource
 
 import (
+	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -43,18 +46,35 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSCodeCommitSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVar(envBranch, src.Spec.Branch),
-			resource.EnvVar(envEventTypes, strings.Join(src.Spec.EventTypes, ",")),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSCodeCommitSource)
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVar(envBranch, typedSrc.Spec.Branch),
+		resource.EnvVar(envEventTypes, strings.Join(typedSrc.Spec.EventTypes, ",")),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awscodecommitsource/controller.go
+++ b/pkg/reconciler/awscodecommitsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSCodeCommitSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awscodecommitsource/controller_test.go
+++ b/pkg/reconciler/awscodecommitsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscodecommitsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awscodecommitsource/reconciler.go
+++ b/pkg/reconciler/awscodecommitsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscodecommitsource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSCodeCommitSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSCodeCom
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awscodecommitsource/reconciler_test.go
+++ b/pkg/reconciler/awscodecommitsource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/codecommit"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSCodeCommitSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSCodeCommitSourceLister().AWSCodeCommitSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -106,4 +95,12 @@ func newEventSource() *v1alpha1.AWSCodeCommitSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/reconciler/awscognitoidentitysource/adapter.go
@@ -17,10 +17,14 @@ limitations under the License.
 package awscognitoidentitysource
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -36,16 +40,33 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoIdentitySource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSCognitoIdentitySource)
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awscognitoidentitysource/controller.go
+++ b/pkg/reconciler/awscognitoidentitysource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSCognitoIdentitySources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awscognitoidentitysource/controller_test.go
+++ b/pkg/reconciler/awscognitoidentitysource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscognitoidentitysource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awscognitoidentitysource/reconciler.go
+++ b/pkg/reconciler/awscognitoidentitysource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscognitoidentitysource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSCognitoIdentitySourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSCognito
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awscognitoidentitysource/reconciler_test.go
+++ b/pkg/reconciler/awscognitoidentitysource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSCognitoIdentitySource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSCognitoIdentitySourceLister().AWSCognitoIdentitySources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -104,4 +93,12 @@ func newEventSource() *v1alpha1.AWSCognitoIdentitySource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/reconciler/awscognitouserpoolsource/adapter.go
@@ -17,15 +17,21 @@ limitations under the License.
 package awscognitouserpoolsource
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -36,21 +42,36 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-const healthPortName = "health"
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSCognitoUserPoolSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSCognitoUserPoolSource)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
 
-			resource.Port(healthPortName, 8080),
-			resource.Probe("/health", healthPortName),
-		)
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.Probe("/health", healthPortName),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awscognitouserpoolsource/controller.go
+++ b/pkg/reconciler/awscognitouserpoolsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSCognitoUserPoolSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awscognitouserpoolsource/controller_test.go
+++ b/pkg/reconciler/awscognitouserpoolsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awscognitouserpoolsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awscognitouserpoolsource/reconciler.go
+++ b/pkg/reconciler/awscognitouserpoolsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awscognitouserpoolsource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSCognitoUserPoolSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSCognito
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awscognitouserpoolsource/reconciler_test.go
+++ b/pkg/reconciler/awscognitouserpoolsource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSCognitoUserPoolSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSCognitoUserPoolSourceLister().AWSCognitoUserPoolSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -104,4 +93,12 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSCognitoUserPoo
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/reconciler/awsdynamodbsource/adapter.go
@@ -17,10 +17,14 @@ limitations under the License.
 package awsdynamodbsource
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -36,16 +40,33 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSDynamoDBSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSDynamoDBSource)
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/reconciler/awsdynamodbsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSDynamoDBSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awsdynamodbsource/controller_test.go
+++ b/pkg/reconciler/awsdynamodbsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awsdynamodbsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awsdynamodbsource/reconciler.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsdynamodbsource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSDynamoDBSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSDynamoD
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/reconciler/awsdynamodbsource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSDynamoDBSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSDynamoDBSourceLister().AWSDynamoDBSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -104,4 +93,12 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSDynamoDBSource
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awsiotsource/adapter.go
+++ b/pkg/reconciler/awsiotsource/adapter.go
@@ -17,12 +17,15 @@ limitations under the License.
 package awsiotsource
 
 import (
+	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
@@ -49,28 +52,45 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSIoTSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-			resource.EnvVar(envEndpoint, src.Spec.Endpoint),
-			resource.EnvVar(envTopic, strings.TrimPrefix(src.Spec.ARN.Resource, "topic/")),
-			resource.EnvVarFromSecret(envRootCA,
-				src.Spec.RootCA.ValueFromSecret.Name,
-				src.Spec.RootCA.ValueFromSecret.Key),
-			resource.EnvVar(envRootCAPath, *src.Spec.RootCAPath),
-			resource.EnvVarFromSecret(envCertificate,
-				src.Spec.Certificate.ValueFromSecret.Name,
-				src.Spec.Certificate.ValueFromSecret.Key),
-			resource.EnvVar(envCertificatePath, *src.Spec.CertificatePath),
-			resource.EnvVarFromSecret(envPrivateKey,
-				src.Spec.PrivateKey.ValueFromSecret.Name,
-				src.Spec.PrivateKey.ValueFromSecret.Key),
-			resource.EnvVar(envPrivateKeyPath, *src.Spec.PrivateKeyPath),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSIoTSource)
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(envEndpoint, typedSrc.Spec.Endpoint),
+		resource.EnvVar(envTopic, strings.TrimPrefix(typedSrc.Spec.ARN.Resource, "topic/")),
+		resource.EnvVarFromSecret(envRootCA,
+			typedSrc.Spec.RootCA.ValueFromSecret.Name,
+			typedSrc.Spec.RootCA.ValueFromSecret.Key),
+		resource.EnvVar(envRootCAPath, *typedSrc.Spec.RootCAPath),
+		resource.EnvVarFromSecret(envCertificate,
+			typedSrc.Spec.Certificate.ValueFromSecret.Name,
+			typedSrc.Spec.Certificate.ValueFromSecret.Key),
+		resource.EnvVar(envCertificatePath, *typedSrc.Spec.CertificatePath),
+		resource.EnvVarFromSecret(envPrivateKey,
+			typedSrc.Spec.PrivateKey.ValueFromSecret.Name,
+			typedSrc.Spec.PrivateKey.ValueFromSecret.Key),
+		resource.EnvVar(envPrivateKeyPath, *typedSrc.Spec.PrivateKeyPath),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awsiotsource/controller.go
+++ b/pkg/reconciler/awsiotsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSIoTSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awsiotsource/controller_test.go
+++ b/pkg/reconciler/awsiotsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awsiotsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awsiotsource/reconciler.go
+++ b/pkg/reconciler/awsiotsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awsiotsource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSIoTSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSIoTSour
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awsiotsource/reconciler_test.go
+++ b/pkg/reconciler/awsiotsource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,14 +24,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/iot"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -55,28 +52,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSIoTSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSIoTSourceLister().AWSIoTSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -109,4 +98,12 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSIoTSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awskinesissource/controller.go
+++ b/pkg/reconciler/awskinesissource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSKinesisSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awskinesissource/controller_test.go
+++ b/pkg/reconciler/awskinesissource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awskinesissource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awskinesissource/reconciler.go
+++ b/pkg/reconciler/awskinesissource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awskinesissource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSKinesisSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSKinesis
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/reconciler/awskinesissource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSKinesisSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSKinesisSourceLister().AWSKinesisSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -104,4 +93,12 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSKinesisSource 
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/awssnssource/controller.go
+++ b/pkg/reconciler/awssnssource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,8 +52,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSSNSSources,
 		snsCg:      newClientGetter(k8sclient.Get(ctx).CoreV1().Secrets),
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
@@ -65,7 +68,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), informerResyncPeriod)
+	informer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), informerResyncPeriod)
 
 	return impl
 }

--- a/pkg/reconciler/awssnssource/controller_test.go
+++ b/pkg/reconciler/awssnssource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,8 @@ import (
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awssnssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/service/fake"
 )

--- a/pkg/reconciler/awssnssource/reconciler.go
+++ b/pkg/reconciler/awssnssource/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -32,7 +33,9 @@ type Reconciler struct {
 	base       common.GenericServiceReconciler
 	adapterCfg *adapterConfig
 
-	// SNS client interface
+	srcLister func(namespace string) listersv1alpha1.AWSSNSSourceNamespaceLister
+
+	// SNS client interface to interact with the SNS API
 	snsCg ClientGetter
 }
 
@@ -47,7 +50,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSSNSSour
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	if err := r.base.ReconcileSource(ctx, adapterServiceBuilder(src, r.adapterCfg)); err != nil {
+	if err := r.base.ReconcileSource(ctx, r); err != nil {
 		return fmt.Errorf("failed to reconcile source: %w", err)
 	}
 

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -17,16 +17,22 @@ limitations under the License.
 package awssqssource
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	kr "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -37,36 +43,51 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-const healthPortName = "health"
+// Verify that Reconciler implements common.AdapterDeploymentBuilder.
+var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 
-// adapterDeploymentBuilder returns an AdapterDeploymentBuilderFunc for the
-// given source object and adapter config.
-func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) common.AdapterDeploymentBuilderFunc {
-	return func(sinkURI *apis.URL) *appsv1.Deployment {
-		return common.NewAdapterDeployment(src, sinkURI,
-			resource.Image(cfg.Image),
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment {
+	typedSrc := src.(*v1alpha1.AWSSQSSource)
 
-			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
-			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
-			resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-			resource.EnvVar(common.EnvName, src.GetName()),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
 
-			resource.Port(healthPortName, 8080),
-			resource.Port("metrics", 9090),
+		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
+		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
+		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
+		resource.EnvVar(common.EnvName, src.GetName()),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
-			resource.Probe("/health", healthPortName),
+		resource.Port(healthPortName, 8080),
+		resource.Port("metrics", 9090),
 
-			// CPU throttling can be observed below a limit of 1,
-			// although the CPU usage under load remains below 400m.
-			resource.Requests(
-				*kr.NewMilliQuantity(90, kr.DecimalSI),     // 90m
-				*kr.NewQuantity(1024*1024*30, kr.BinarySI), // 30Mi
-			),
-			resource.Limits(
-				*kr.NewMilliQuantity(1000, kr.DecimalSI),   // 1
-				*kr.NewQuantity(1024*1024*45, kr.BinarySI), // 45Mi
-			),
-		)
+		resource.Probe("/health", healthPortName),
+
+		// CPU throttling can be observed below a limit of 1,
+		// although the CPU usage under load remains below 400m.
+		resource.Requests(
+			*kr.NewMilliQuantity(90, kr.DecimalSI),     // 90m
+			*kr.NewQuantity(1024*1024*30, kr.BinarySI), // 30Mi
+		),
+		resource.Limits(
+			*kr.NewMilliQuantity(1000, kr.DecimalSI),   // 1
+			*kr.NewQuantity(1024*1024*45, kr.BinarySI), // 45Mi
+		),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/awssqssource/adapter.go
+++ b/pkg/reconciler/awssqssource/adapter.go
@@ -48,6 +48,8 @@ func adapterDeploymentBuilder(src *v1alpha1.AWSSQSSource, cfg *adapterConfig) co
 
 			resource.EnvVar(common.EnvARN, src.Spec.ARN.String()),
 			resource.EnvVars(common.MakeSecurityCredentialsEnvVars(src.Spec.Credentials)...),
+			resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
+			resource.EnvVar(common.EnvName, src.GetName()),
 			resource.EnvVars(cfg.configs.ToEnvVars()...),
 
 			resource.Port(healthPortName, 8080),

--- a/pkg/reconciler/awssqssource/controller.go
+++ b/pkg/reconciler/awssqssource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().AWSSQSSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/awssqssource/controller_test.go
+++ b/pkg/reconciler/awssqssource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import (
 	_ "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awssqssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/awssqssource/reconciler.go
+++ b/pkg/reconciler/awssqssource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssqssource"
+	listersv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/aws-event-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericDeploymentReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.AWSSQSSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSSQSSour
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterDeploymentBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/reconciler/awssqssource/reconciler_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/resolver"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client/fake"
@@ -45,28 +42,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterDeploymentBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a AWSSQSSource Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
 	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
-		base := common.GenericDeploymentReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetDeploymentLister().Deployments,
-			Client:       fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-			PodClient:    fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
-		}
-
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestDeploymentReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetAWSSQSSourceLister().AWSSQSSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -104,4 +93,12 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSSQSSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -22,9 +22,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -34,17 +38,16 @@ import (
 const metricsPrometheusPort uint16 = 9092
 
 // AdapterName returns the adapter's name for the given source object.
-func AdapterName(o kmeta.OwnerRefable) string {
-	return strings.ToLower(o.GetGroupVersionKind().Kind)
+func AdapterName(src kmeta.OwnerRefable) string {
+	return strings.ToLower(src.GetGroupVersionKind().Kind)
 }
 
 // NewAdapterDeployment is a wrapper around resource.NewDeployment which
 // pre-populates attributes common to all adapter Deployments.
-func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...resource.ObjectOption) *appsv1.Deployment {
+func NewAdapterDeployment(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *appsv1.Deployment {
 	app := AdapterName(src)
-	meta := src.GetObjectMeta()
-	srcNs := meta.GetNamespace()
-	srcName := meta.GetName()
+	srcNs := src.GetNamespace()
+	srcName := src.GetName()
 
 	var sinkURIStr string
 	if sinkURI != nil {
@@ -68,8 +71,8 @@ func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...res
 			resource.PodLabel(appPartOfLabel, partOf),
 			resource.PodLabel(appManagedByLabel, managedBy),
 
-			resource.EnvVar(envNamespace, srcNs),
-			resource.EnvVar(envName, srcName),
+			resource.ServiceAccount(AdapterRBACObjectsName(src)),
+
 			resource.EnvVar(envSink, sinkURIStr),
 		}, opts...)...,
 	)
@@ -77,11 +80,10 @@ func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...res
 
 // NewAdapterKnService is a wrapper around resource.NewKnService which
 // pre-populates attributes common to all adapter Knative Services.
-func NewAdapterKnService(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...resource.ObjectOption) *servingv1.Service {
+func NewAdapterKnService(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *servingv1.Service {
 	app := AdapterName(src)
-	meta := src.GetObjectMeta()
-	srcNs := meta.GetNamespace()
-	srcName := meta.GetName()
+	srcNs := src.GetNamespace()
+	srcName := src.GetName()
 
 	var sinkURIStr string
 	if sinkURI != nil {
@@ -104,12 +106,80 @@ func NewAdapterKnService(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...reso
 			resource.PodLabel(appPartOfLabel, partOf),
 			resource.PodLabel(appManagedByLabel, managedBy),
 
-			resource.EnvVar(envNamespace, srcNs),
-			resource.EnvVar(envName, srcName),
+			resource.ServiceAccount(AdapterRBACObjectsName(src)),
+
 			resource.EnvVar(envSink, sinkURIStr),
 			resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
 		}, opts...)...,
 	)
+}
+
+// newServiceAccount returns a ServiceAccount object with its OwnerReferences
+// metadata attribute populated from the given owners.
+func newServiceAccount(src v1alpha1.EventSource, owners []kmeta.OwnerRefable) *corev1.ServiceAccount {
+	ownerRefs := make([]metav1.OwnerReference, len(owners))
+	for i, owner := range owners {
+		ownerRefs[i] = *kmeta.NewControllerRef(owner)
+		ownerRefs[i].Controller = ptr.Bool(false)
+	}
+
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       src.GetNamespace(),
+			Name:            AdapterRBACObjectsName(src),
+			OwnerReferences: ownerRefs,
+			Labels:          RBACObjectLabels(src),
+		},
+	}
+
+}
+
+// newRoleBinding returns a RoleBinding object that binds a ServiceAccount
+// (namespace-scoped) to a ClusterRole (cluster-scoped).
+func newRoleBinding(src v1alpha1.EventSource, owner *corev1.ServiceAccount) *rbacv1.RoleBinding {
+	crGVK := rbacv1.SchemeGroupVersion.WithKind("ClusterRole")
+	saGVK := corev1.SchemeGroupVersion.WithKind("ServiceAccount")
+
+	ns := src.GetNamespace()
+	n := AdapterRBACObjectsName(src)
+
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      n,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(owner, saGVK),
+			},
+			Labels: RBACObjectLabels(src),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: crGVK.Group,
+			Kind:     crGVK.Kind,
+			Name:     n,
+		},
+		Subjects: []rbacv1.Subject{{
+			APIGroup:  saGVK.Group,
+			Kind:      saGVK.Kind,
+			Namespace: ns,
+			Name:      n,
+		}},
+	}
+}
+
+// AdapterRBACObjectsName returns a unique name to apply to all RBAC objects
+// for the given source's adapter.
+func AdapterRBACObjectsName(src kmeta.OwnerRefable) string {
+	return AdapterName(src) + "-" + componentAdapter
+}
+
+// RBACObjectLabels returns a set of labels to be applied to reconciled RBAC objects.
+func RBACObjectLabels(src kmeta.OwnerRefable) labels.Set {
+	return labels.Set{
+		appNameLabel:      AdapterName(src),
+		appComponentLabel: componentAdapter,
+		appPartOfLabel:    partOf,
+		appManagedByLabel: managedBy,
+	}
 }
 
 // MakeSecurityCredentialsEnvVars returns environment variables for the given

--- a/pkg/reconciler/common/base.go
+++ b/pkg/reconciler/common/base.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,11 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	rbaclistersv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 
 	k8sclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformerv1 "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+	sainformerv1 "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	rbinformerv1 "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/resolver"
 	servingclientv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
@@ -45,6 +50,8 @@ type GenericDeploymentReconciler struct {
 	PodClient func(namespace string) coreclientv1.PodInterface
 	// objects listers
 	Lister func(namespace string) appslistersv1.DeploymentNamespaceLister
+
+	*GenericRBACReconciler
 }
 
 // GenericServiceReconciler contains interfaces shared across Service reconcilers.
@@ -55,6 +62,18 @@ type GenericServiceReconciler struct {
 	Client func(namespace string) servingclientv1.ServiceInterface
 	// objects listers
 	Lister func(namespace string) servinglistersv1.ServiceNamespaceLister
+
+	*GenericRBACReconciler
+}
+
+// GenericRBACReconciler reconciles RBAC objects for source adapters.
+type GenericRBACReconciler struct {
+	// API clients
+	SAClient func(namespace string) coreclientv1.ServiceAccountInterface
+	RBClient func(namespace string) rbacclientv1.RoleBindingInterface
+	// objects listers
+	SALister func(namespace string) corelistersv1.ServiceAccountNamespaceLister
+	RBLister func(namespace string) rbaclistersv1.RoleBindingNamespaceLister
 }
 
 // NewGenericDeploymentReconciler creates a new GenericDeploymentReconciler and
@@ -67,10 +86,11 @@ func NewGenericDeploymentReconciler(ctx context.Context, gvk schema.GroupVersion
 	informer := deploymentinformerv1.Get(ctx)
 
 	r := GenericDeploymentReconciler{
-		SinkResolver: resolver.NewURIResolver(ctx, resolverCallback),
-		Client:       k8sclient.Get(ctx).AppsV1().Deployments,
-		PodClient:    k8sclient.Get(ctx).CoreV1().Pods,
-		Lister:       informer.Lister().Deployments,
+		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
+		Client:                k8sclient.Get(ctx).AppsV1().Deployments,
+		PodClient:             k8sclient.Get(ctx).CoreV1().Pods,
+		Lister:                informer.Lister().Deployments,
+		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
 	}
 
 	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -91,9 +111,10 @@ func NewGenericServiceReconciler(ctx context.Context, gvk schema.GroupVersionKin
 	informer := serviceinformerv1.Get(ctx)
 
 	r := GenericServiceReconciler{
-		SinkResolver: resolver.NewURIResolver(ctx, resolverCallback),
-		Client:       servingclient.Get(ctx).ServingV1().Services,
-		Lister:       informer.Lister().Services,
+		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
+		Client:                servingclient.Get(ctx).ServingV1().Services,
+		Lister:                informer.Lister().Services,
+		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
 	}
 
 	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -102,4 +123,14 @@ func NewGenericServiceReconciler(ctx context.Context, gvk schema.GroupVersionKin
 	})
 
 	return r
+}
+
+// NewGenericRbacReconciler creates a new GenericRbacReconciler.
+func NewGenericRbacReconciler(ctx context.Context) *GenericRBACReconciler {
+	return &GenericRBACReconciler{
+		SAClient: k8sclient.Get(ctx).CoreV1().ServiceAccounts,
+		RBClient: k8sclient.Get(ctx).RbacV1().RoleBindings,
+		SALister: sainformerv1.Get(ctx).Lister().ServiceAccounts,
+		RBLister: rbinformerv1.Get(ctx).Lister().RoleBindings,
+	}
 }

--- a/pkg/reconciler/common/doc.go
+++ b/pkg/reconciler/common/doc.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package common contains constants shared by reconcilers.
+// Package common contains reconciliation helpers shared by source reconcilers.
 package common

--- a/pkg/reconciler/common/env.go
+++ b/pkg/reconciler/common/env.go
@@ -18,10 +18,10 @@ package common
 
 // Common environment variables propagated to adapters.
 const (
-	envName      = "NAME"
-	envNamespace = "NAMESPACE"
-	envSink      = "K_SINK"
+	EnvName      = "NAME"
+	EnvNamespace = "NAMESPACE"
 
+	envSink                  = "K_SINK"
 	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
 
 	EnvARN             = "ARN"

--- a/pkg/reconciler/common/events.go
+++ b/pkg/reconciler/common/events.go
@@ -18,6 +18,15 @@ package common
 
 // Reasons for API Events
 const (
+	// ReasonRBACCreate indicates that an RBAC object was successfully created.
+	ReasonRBACCreate = "CreateRBAC"
+	// ReasonRBACUpdate indicates that an RBAC object was successfully updated.
+	ReasonRBACUpdate = "UpdateRBAC"
+	// ReasonFailedRBACCreate indicates that the creation of an RBAC object failed.
+	ReasonFailedRBACCreate = "FailedRBACCreate"
+	// ReasonFailedRBACUpdate indicates that the update of an RBAC object failed.
+	ReasonFailedRBACUpdate = "FailedRBACUpdate"
+
 	// ReasonAdapterCreate indicates that an adapter object was successfully created.
 	ReasonAdapterCreate = "CreateAdapter"
 	// ReasonAdapterUpdate indicates that an adapter object was successfully updated.

--- a/pkg/reconciler/common/resource/deployment_test.go
+++ b/pkg/reconciler/common/resource/deployment_test.go
@@ -44,6 +44,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		ServiceAccount("god-mode"),
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		TerminationErrorToLogs,
@@ -75,6 +76,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "god-mode",
 					Containers: []corev1.Container{{
 						Name:  defaultContainerName,
 						Image: tImg,

--- a/pkg/reconciler/common/resource/knservice_test.go
+++ b/pkg/reconciler/common/resource/knservice_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,6 +41,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		ServiceAccount("god-mode"),
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
@@ -65,6 +66,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 					},
 					Spec: servingv1.RevisionSpec{
 						PodSpec: corev1.PodSpec{
+							ServiceAccountName: "god-mode",
 							Containers: []corev1.Container{{
 								Name:  defaultContainerName,
 								Image: tImg,

--- a/pkg/reconciler/common/resource/podspecable.go
+++ b/pkg/reconciler/common/resource/podspecable.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -51,5 +51,21 @@ func Container(c *corev1.Container) ObjectOption {
 			containers := &o.Spec.Template.Spec.Containers
 			*containers = []corev1.Container{*c}
 		}
+	}
+}
+
+// ServiceAccount sets the ServiceAccount name of a PodSpecable.
+func ServiceAccount(sa string) ObjectOption {
+	return func(object interface{}) {
+		var saName *string
+
+		switch o := object.(type) {
+		case *appsv1.Deployment:
+			saName = &o.Spec.Template.Spec.ServiceAccountName
+		case *servingv1.Service:
+			saName = &o.Spec.Template.Spec.ServiceAccountName
+		}
+
+		*saName = sa
 	}
 }

--- a/pkg/reconciler/testing/controller.go
+++ b/pkg/reconciler/testing/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,8 +40,8 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 
 	ctx, informers := rt.SetupFakeContext(t)
 
-	// expected informers: Source, Deployment
-	if expect, got := 2, len(informers); got != expect {
+	// expected informers: Source, Deployment, ServiceAccount, RoleBinding
+	if expect, got := 4, len(informers); got != expect {
 		t.Errorf("Expected %d injected informers, got %d", expect, got)
 	}
 

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,9 +20,13 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
-	k8slistersv1 "k8s.io/client-go/listers/apps/v1"
+	appslistersv1 "k8s.io/client-go/listers/apps/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	rbaclistersv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
@@ -145,11 +149,21 @@ func (l *Listers) GetAWSSQSSourceLister() listersv1alpha1.AWSSQSSourceLister {
 }
 
 // GetDeploymentLister returns a lister for Deployment objects.
-func (l *Listers) GetDeploymentLister() k8slistersv1.DeploymentLister {
-	return k8slistersv1.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
+func (l *Listers) GetDeploymentLister() appslistersv1.DeploymentLister {
+	return appslistersv1.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
 }
 
-// GetServiceLister returns a lister for Service objects.
+// GetServiceLister returns a lister for Knative Service objects.
 func (l *Listers) GetServiceLister() servinglistersv1.ServiceLister {
 	return servinglistersv1.NewServiceLister(l.IndexerFor(&servingv1.Service{}))
+}
+
+// GetServiceAccountLister returns a lister for ServiceAccount objects.
+func (l *Listers) GetServiceAccountLister() corelistersv1.ServiceAccountLister {
+	return corelistersv1.NewServiceAccountLister(l.IndexerFor(&corev1.ServiceAccount{}))
+}
+
+// GetRoleBindingLister returns a lister for RoleBinding objects
+func (l *Listers) GetRoleBindingLister() rbaclistersv1.RoleBindingLister {
+	return rbaclistersv1.NewRoleBindingLister(l.IndexerFor(&rbacv1.RoleBinding{}))
 }


### PR DESCRIPTION
**Part 1 of the multi-tenancy story.**

When a `AWS*Source` object is created, synchronize a `ServiceAccount` and the corresponding `RoleBinding` for that type to be used by the corresponding adapter(s).

No matter how many instances of `AWS*Source` the namespace contains, there is always a _single_ pair of `ServiceAccount`+`RoleBinding` that gets reconciled:

```console
$ kubectl -n dev get awssnssource,sa,rolebinding

NAME                                          READY   REASON               AGE   URL
awssnssource.sources.triggermesh.io/sample0   False   AdapterUnavailable   20m
awssnssource.sources.triggermesh.io/sample1   False   AdapterUnavailable   20m
awssnssource.sources.triggermesh.io/sample2   False   AdapterUnavailable   20m

NAME                                  SECRETS   AGE
serviceaccount/default                1         5d18h
serviceaccount/awssnssource-adapter   1         20m

NAME                                                         AGE
rolebinding.rbac.authorization.k8s.io/awssnssource-adapter   20m
```


The object hierarchy is:
```
+------------+    +------------+    +------------+
| AWS*Source |    | AWS*Source |    | AWS*Source |
+-------+----+    +-----+------+    +-------+----+
        |               |                   |
        +-------------- | ------------------+
                        |
                +-------v--------+
                | ServiceAccount |
                +-------+--------+
                        |
                        |
                 +------v------+
                 | RoleBinding |
                 +-------------+

```

`AWS*Source` receive adapters are configured to use that ServiceAccount:

```console
$ kubectl -n dev get ksvc awssnssource-sample0 -o yaml

apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: awssnssource-sample0
  namespace: dev
spec:
  template:
    spec:
      serviceAccountName: awssnssource-adapter
```

Deleting _some_ `AWS*Source` does not cause the deletion of the `ServiceAccount`+`RoleBinding` combo...

```console
$ kubectl -n dev delete awssnssource sample0 sample1

awssnssource.sources.triggermesh.io "sample0" deleted
awssnssource.sources.triggermesh.io "sample1" deleted
```

```console
$ kubectl -n dev get awssnssource,sa,rolebinding

NAME                                          READY   REASON               AGE   URL
awssnssource.sources.triggermesh.io/sample2   False   AdapterUnavailable   22m

NAME                                  SECRETS   AGE
serviceaccount/default                1         5d18h
serviceaccount/awssnssource-adapter   1         22m

NAME                                                         AGE
rolebinding.rbac.authorization.k8s.io/awssnssource-adapter   2m
```

... however, deleting _all_ `AWS*Source` causes the deletion of both RBAC objects:

```console
$ kubectl -n dev delete awssnssource sample2

awssnssource.sources.triggermesh.io "sample2" deleted
```

```console
$ kubectl -n dev get awssnssource,sa,rolebinding

NAME                        SECRETS   AGE
serviceaccount/default      1         5d18h
```

The controller emits informative events at the namespace-level when it creates/updates a `ServiceAccount` or `RoleBinding`:

```console
$ kubectl get events

LAST SEEN   TYPE      REASON      OBJECT          MESSAGE
34m         Normal    CreateRBAC  namespace/dev   ServiceAccount "awssnssource-adapter" created due to the creation of a AWSSNSSource object
34m         Normal    CreateRBAC  namespace/dev   RoleBinding "awssnssource-adapter" created due to the creation of a AWSSNSSource object
23m         Normal    UpdateRBAC  namespace/dev   ServiceAccount "awssnssource-adapter" updated due to the creation/deletion of a AWSSNSSource object
9m55s       Normal    UpdateRBAC  namespace/dev   ServiceAccount "awssnssource-adapter" updated due to the creation/deletion of a AWSSNSSource object
9m33s       Normal    UpdateRBAC  namespace/dev   ServiceAccount "awssnssource-adapter" updated due to the creation/deletion of a AWSSNSSource object
```