### PR TITLE
sns: Handle all SNS API errors

### DIFF
--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -88,6 +88,8 @@ const (
 	AWSSNSReasonNoClient = "NoClient"
 	// AWSSNSReasonRejected is set on a Subscribed condition when the SNS API rejects a subscription request.
 	AWSSNSReasonRejected = "SubscriptionRejected"
+	// AWSSNSReasonAPIError is set on a Subscribed condition when the SNS API returns any other error.
+	AWSSNSReasonAPIError = "APIError"
 	// AWSSNSReasonFailedSync is set on a Subscribed condition when other synchronization errors occur.
 	AWSSNSReasonFailedSync = "FailedSync"
 )

--- a/pkg/reconciler/awssnssource/subscription_test.go
+++ b/pkg/reconciler/awssnssource/subscription_test.go
@@ -18,6 +18,7 @@ package awssnssource
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,10 +44,16 @@ func TestErrors(t *testing.T) {
 	t.Run("denied", func(t *testing.T) {
 		deniedErr := awserr.New(sns.ErrCodeAuthorizationErrorException, "an error", assert.AnError)
 
+		reqFailErr := func(httpCode int) error {
+			return awserr.NewRequestFailure(genericAWSErr, httpCode, "00000000-0000-...")
+		}
+
 		assert.True(t, isDenied(deniedErr))
 		assert.True(t, isDenied(fmt.Errorf("wrapped: %w", deniedErr)))
+		assert.True(t, isDenied(reqFailErr(http.StatusUnauthorized)))
 		assert.False(t, isDenied(genericAWSErr))
 		assert.False(t, isDenied(genericErr))
+		assert.False(t, isDenied(reqFailErr(http.StatusBadRequest)))
 	})
 
 	t.Run("not found", func(t *testing.T) {


### PR DESCRIPTION
Fixes #260

A small PR that addresses 3 issues related to error handling.

---

1\. Fixes an issue where some SNS API errors were not properly handled, causing a flood of Kubernetes events and unnecessary retries:

```
Events:
  Type     Reason           Age     From                     Message
  ----     ------           ----    ----                     -------
  Warning  InternalError    26m     awssnssource-controller  finding subscription: listing subscriptions for topic: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
           status code: 403, request id: f063e0aa-fb07-5cd3-8ac9-b8203ae0d906
  Warning  InternalError    26m     awssnssource-controller  finding subscription: listing subscriptions for topic: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
           status code: 403, request id: 42c0fe91-2ca3-5c40-81e4-a61bed4be995
  Warning  InternalError    26m     awssnssource-controller  finding subscription: listing subscriptions for topic: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
           status code: 403, request id: 92314bbf-e817-5f9f-b6ac-133529ffca4a
  Warning  InternalError    26m     awssnssource-controller  finding subscription: listing subscriptions for topic: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
           status code: 403, request id: 07e4d475-0f38-55b6-87d4-8cffced0d063
  Warning  InternalError    5m18s (x16 over 26m)  awssnssource-controller  (combined from similar events): finding subscription: listing subscriptions for topic: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
           status code: 403, request id: 07e858f6-ce03-5acf-8cda-007c08c4cd7d
...
 ```

SNS API errors are now correctly handled, and unretriable errors aren't retried:
 
```
Events:
  Type     Reason           Age     From                     Message
  ----     ------           ----    ----                     -------
  Warning  FailedSubscribe  19s     awssnssource-controller  Error communicating with the SNS API: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```

---

2\. When an API error prevents the reconciler from listing existing subscriptions, the reason "APIError" is now correctly propagated to the source's status:

```console
$ kubectl get awssnssources.sources.triggermesh.io sample
NAME     READY   REASON     URL                                              SINK                                             AGE
sample   False   APIError   http://awssnssource-sample.default.example.com   http://event-display.default.svc.cluster.local   3h9m
```

```yaml
- lastTransitionTime: "2021-01-27T01:45:22Z"
  message: API call rejected
  reason: APIError
  status: "False"
  type: Subscribed
```

---

3\. All API responses with HTTP code `401` or `403` are now considered as denied and handled accordingly (e.g. release the finalizer if this occurs during finalization), not only the ones returned by SNS with the reason "AuthorizationErrorException".