### PR TITLE
Make the SNS source multi-tenant (part 1)

### DIFF
--- a/cmd/awssnssource/main.go
+++ b/cmd/awssnssource/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"knative.dev/eventing/pkg/adapter/v2"
-
 	"github.com/triggermesh/aws-event-sources/pkg/adapter/awssnssource"
+	"github.com/triggermesh/aws-event-sources/pkg/adapter/common/sharedmain"
 )
 
 func main() {
-	adapter.Main("awssnssource", awssnssource.NewEnvConfig, awssnssource.NewAdapter)
+	sharedmain.MainWithController(awssnssource.NewEnvConfig, awssnssource.NewController, awssnssource.NewAdapter)
 }

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -280,7 +280,49 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: awssnssource-adapter
-rules: []
+rules:
+
+# Record Kubernetes events
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+# Read Source resources and update their statuses
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awssnssources
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awssnssources/status
+  verbs:
+  - patch
+
+# Acquire leases for leader election
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - awssnssource.github.com-triggermesh-aws-event-sources-pkg-adapter-awssnssource.reconciler.00-of-01
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 
 ---
 

--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,34 +17,3 @@ kind: ServiceAccount
 metadata:
   name: aws-event-sources-controller
   namespace: triggermesh
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: &app aws-event-sources-controller
-subjects:
-- kind: ServiceAccount
-  name: *app
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: *app
-
----
-
-# Resolve sink URIs
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aws-event-sources-controller-addressable-resolver
-subjects:
-- kind: ServiceAccount
-  name: aws-event-sources-controller
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: addressable-resolver

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -1,0 +1,181 @@
+# Copyright (c) 2021 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app aws-event-sources-controller
+subjects:
+- kind: ServiceAccount
+  name: *app
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+
+---
+
+# Permissions not required by controllers directly, but granted to
+# receive-adapters via RoleBindings.
+#
+# Without them, the following error is thrown:
+#   "attempting to grant RBAC permissions not currently held"
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awscloudwatchlogssource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awscloudwatchsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awscodecommitsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awscognitoidentitysource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awscognitouserpoolsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awsdynamodbsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awsiotsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awskinesissource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awssnssource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app awssqssource-adapter
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+
+---
+
+# Resolve sink URIs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-event-sources-controller-addressable-resolver
+subjects:
+- kind: ServiceAccount
+  name: aws-event-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver

--- a/pkg/adapter/awssnssource/controller.go
+++ b/pkg/adapter/awssnssource/controller.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssnssource
+
+import (
+	"context"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/apis"
+	pkgcontroller "knative.dev/pkg/controller"
+
+	"github.com/triggermesh/aws-event-sources/pkg/adapter/common/controller"
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	informerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/informers/sources/v1alpha1/awssnssource"
+	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
+)
+
+// MTAdapter allows the multi-tenant adapter to expose methods the reconciler
+// can call while reconciling a source object.
+type MTAdapter interface {
+	// Registers a HTTP handler for the given source.
+	RegisterHandlerFor(context.Context, *v1alpha1.AWSSNSSource) error
+	// Deregisters the HTTP handler for the given source.
+	DeregisterHandlerFor(context.Context, *v1alpha1.AWSSNSSource) error
+	// Propagates a status condition to the status of the given source.
+	PropagateCondition(context.Context, *v1alpha1.AWSSNSSource, *apis.Condition) error
+}
+
+// NewController returns a constructor for the event source's Reconciler.
+func NewController(component string) pkgadapter.ControllerConstructor {
+	return func(ctx context.Context, a pkgadapter.Adapter) *pkgcontroller.Impl {
+		r := &Reconciler{
+			adapter: a.(MTAdapter),
+		}
+		impl := reconcilerv1alpha1.NewImpl(ctx, r, controller.Opts(component))
+
+		informerv1alpha1.Get(ctx).Informer().AddEventHandler(pkgcontroller.HandleAll(impl.Enqueue))
+
+		return impl
+	}
+}

--- a/pkg/adapter/awssnssource/events.go
+++ b/pkg/adapter/awssnssource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package awssnssource
 
-// Common environment variables propagated to adapters.
+// Reasons for API Events
 const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
-
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
-
-	EnvARN             = "ARN"
-	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
+	ReasonSourceNotReady      = "NotReady"
+	ReasonHandlerDeregistered = "Deregistered"
 )

--- a/pkg/adapter/awssnssource/reconciler.go
+++ b/pkg/adapter/awssnssource/reconciler.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssnssource
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/reconciler"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	reconcilerv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/awssnssource"
+)
+
+// Reconciler implements controller.Reconciler for the event source type.
+type Reconciler struct {
+	adapter MTAdapter
+}
+
+// Check the interfaces Reconciler should implement.
+var (
+	_ reconcilerv1alpha1.Interface         = (*Reconciler)(nil)
+	_ reconcilerv1alpha1.ReadOnlyInterface = (*Reconciler)(nil)
+	_ reconcilerv1alpha1.ReadOnlyFinalizer = (*Reconciler)(nil)
+)
+
+// ReconcileKind implements reconcilerv1alpha1.Interface.
+func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.AWSSNSSource) reconciler.Event {
+	if err := r.reconcile(ctx, src); err != nil {
+		return err
+	}
+
+	// TODO(antoineco): switch to true and adjust reason and message once
+	// routing is implemented
+	cond := &apis.Condition{
+		Type:    v1alpha1.AWSSNSConditionHandlerRegistered,
+		Status:  corev1.ConditionFalse,
+		Reason:  "TODO",
+		Message: "Multi-tenancy not implemented",
+	}
+
+	if err := r.adapter.PropagateCondition(ctx, src, cond); err != nil {
+		return fmt.Errorf("propagating status condition: %w", err)
+	}
+
+	return nil
+}
+
+// ObserveKind implements reconcilerv1alpha1.ReadOnlyInterface.
+func (r *Reconciler) ObserveKind(ctx context.Context, src *v1alpha1.AWSSNSSource) reconciler.Event {
+	return r.reconcile(ctx, src)
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, src *v1alpha1.AWSSNSSource) error {
+	if src.Status.SinkURI == nil {
+		// Mark that error as permanent so we don't retry until the
+		// source's status has been updated, which automatically
+		// triggers a new reconciliation.
+		return controller.NewPermanentError(reconciler.NewEvent(corev1.EventTypeWarning, ReasonSourceNotReady,
+			"Event sink URL wasn't resolved yet. Skipping adapter configuration"))
+	}
+
+	if err := r.adapter.RegisterHandlerFor(ctx, src); err != nil {
+		return fmt.Errorf("registering HTTP handler: %w", err)
+	}
+
+	return nil
+}
+
+// ObserveFinalizeKind implements reconcilerv1alpha1.ReadOnlyFinalizer.
+func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, src *v1alpha1.AWSSNSSource) reconciler.Event {
+	return r.finalize(ctx, src)
+}
+
+func (r *Reconciler) finalize(ctx context.Context, src *v1alpha1.AWSSNSSource) error {
+	if err := r.adapter.DeregisterHandlerFor(ctx, src); err != nil {
+		return fmt.Errorf("deregistering HTTP handler: %w", err)
+	}
+
+	return reconciler.NewEvent(corev1.EventTypeNormal, ReasonHandlerDeregistered,
+		"HTTP handler deregistered")
+}

--- a/pkg/adapter/awssnssource/status/condition.go
+++ b/pkg/adapter/awssnssource/status/condition.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+)
+
+// PropagateCondition propagates a status condition to the status of the given
+// source object using the provided Patcher.
+func PropagateCondition(ctx context.Context, p *Patcher, src *v1alpha1.AWSSNSSource, cond *apis.Condition) error {
+	srcCpy := shallowSourceCopy(src)
+	stMan := srcCpy.GetStatusManager()
+	condMan := stMan.Manage(stMan)
+
+	switch cond.Status {
+	case corev1.ConditionTrue:
+		condMan.MarkTrue(cond.Type)
+	case corev1.ConditionFalse:
+		condMan.MarkFalse(cond.Type, cond.Reason, cond.Message)
+	}
+
+	patch, err := duck.CreatePatch(src, srcCpy)
+	if err != nil {
+		return fmt.Errorf("creating JSON patch for status condition: %w", err)
+	}
+	if len(patch) == 0 {
+		return nil
+	}
+
+	if _, err = p.Patch(ctx, src.Name, patch); err != nil {
+		return fmt.Errorf("applying JSON patch: %w", err)
+	}
+	return nil
+}
+
+// shallowSourceCopy returns a shallow copy of the provided source object, with
+// the exception of Status.Conditions which are deeply copied. This allows
+// applying modifications to those status conditions, then generating a JSON
+// patch by comparing the before/after states.
+func shallowSourceCopy(src *v1alpha1.AWSSNSSource) *v1alpha1.AWSSNSSource {
+	srcCpy := *src
+	srcCpy.Status.Conditions = src.Status.Conditions.DeepCopy()
+	return &srcCpy
+}

--- a/pkg/adapter/awssnssource/status/doc.go
+++ b/pkg/adapter/awssnssource/status/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
-
-// Common environment variables propagated to adapters.
-const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
-
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
-
-	EnvARN             = "ARN"
-	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
+// Package status contains types and helpers to manipulate the status of source objects.
+package status

--- a/pkg/adapter/awssnssource/status/patcher.go
+++ b/pkg/adapter/awssnssource/status/patcher.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis/duck"
+
+	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
+	clientv1alpha1 "github.com/triggermesh/aws-event-sources/pkg/client/generated/clientset/internalclientset/typed/sources/v1alpha1"
+	client "github.com/triggermesh/aws-event-sources/pkg/client/generated/injection/client"
+)
+
+// NewPatcher returns a named Patcher scoped at the provided namespace and
+// initialized from the client interface carried by ctx.
+func NewPatcher(component, namespace string, ctx context.Context) *Patcher {
+	return &Patcher{
+		component: component,
+		cli:       client.Get(ctx).SourcesV1alpha1().AWSSNSSources(namespace),
+	}
+}
+
+// Patcher can apply patches to the status of source objects.
+type Patcher struct {
+	component string
+	cli       clientv1alpha1.AWSSNSSourceInterface
+}
+
+// Patch applies the given JSON patch to the status of the source object
+// referenced by name.
+func (p *Patcher) Patch(ctx context.Context, name string, patch duck.JSONPatch) (*v1alpha1.AWSSNSSource, error) {
+	jsonPatch, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("applying JSON patch: %w", err)
+	}
+
+	opts := metav1.PatchOptions{
+		FieldManager: p.component,
+	}
+
+	return p.cli.Patch(ctx, name, types.JSONPatchType, jsonPatch, opts, "status")
+}

--- a/pkg/adapter/common/controller/controller.go
+++ b/pkg/adapter/common/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+// Package controller contains helpers shared between controllers embedded in
+// source adapters.
+package controller
 
-// Common environment variables propagated to adapters.
-const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
+import "knative.dev/pkg/controller"
 
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
-
-	EnvARN             = "ARN"
-	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
-	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
-)
+// Opts returns a callback function that sets the controller's agent name and
+// configures the reconciler to skip status updates.
+func Opts(component string) controller.OptionsFn {
+	return func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			AgentName:         component,
+			SkipStatusUpdates: true,
+		}
+	}
+}

--- a/pkg/adapter/common/env/env.go
+++ b/pkg/adapter/common/env/env.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env allows propagating runtime configurations via the environment.
+package env
+
+import (
+	"github.com/kelseyhightower/envconfig"
+	"knative.dev/eventing/pkg/adapter/v2"
+)
+
+// ConfigAccessor is a superset of adaper.EnvConfigAccessor that overrides
+// properties about certain variables.
+type ConfigAccessor interface {
+	adapter.EnvConfigAccessor
+	// Get the component name.
+	GetComponent() string
+}
+
+// Config is the minimal set of configuration parameters source adapters should support.
+type Config struct {
+	*adapter.EnvConfig
+	// Environment variable containing the namespace of the adapter.
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
+	// Component is the kind of this adapter.
+	Component string `envconfig:"K_COMPONENT" required:"true"`
+}
+
+// Verify that Config implements ConfigAccessor.
+var _ ConfigAccessor = (*Config)(nil)
+
+// GetComponent implements ConfigAccessor.
+func (c *Config) GetComponent() string {
+	return c.Component
+}
+
+// ConfigConstructor is a callback function that returns a ConfigAccessor.
+type ConfigConstructor func() ConfigAccessor
+
+// MustProcessConfig populates the specified adapter.EnvConfigConstructor based
+// on environment variables.
+func MustProcessConfig(envCtor ConfigConstructor) ConfigAccessor {
+	env := envCtor()
+	envconfig.MustProcess("", env)
+	return env
+}

--- a/pkg/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/adapter/common/sharedmain/sharedmain.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedmain
+
+import (
+	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/signals"
+
+	"github.com/triggermesh/aws-event-sources/pkg/adapter/common/env"
+)
+
+type namedControllerConstructor func(component string) adapter.ControllerConstructor
+type namedAdapterConstructor func(component string) adapter.AdapterConstructor
+
+// MainWithController is a shared main tailored to multi-tenant receive-adapters.
+// It performs the following initializations:
+//  * process environment variables
+//  * enable leader election / HA
+//  * set the scope to a single namespace
+//  * inject the given controller constructor
+func MainWithController(envCtor env.ConfigConstructor,
+	cCtor namedControllerConstructor, aCtor namedAdapterConstructor) {
+
+	envAcc := env.MustProcessConfig(envCtor)
+	ns := envAcc.GetNamespace()
+	component := envAcc.GetComponent()
+
+	ctx := signals.NewContext()
+	ctx = adapter.WithHAEnabled(ctx)
+	ctx = injection.WithNamespaceScope(ctx, ns)
+	ctx = adapter.WithController(ctx, cCtor(component))
+
+	adapter.MainWithEnv(ctx, component, envAcc, aCtor(component))
+}

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -78,6 +78,12 @@ const (
 	// AWSSNSConditionSubscribed has status True when the event source's HTTP(S) endpoint has been subscribed to the
 	// SNS subscription.
 	AWSSNSConditionSubscribed apis.ConditionType = "Subscribed"
+
+	// AWSSNSConditionHandlerRegistered indicates that a HTTP handler was registered for the source object.
+	// It is not part of the ConditionSet registered for the AWSSNSSource
+	// type, and will therefore automatically be propagated by Knative with
+	// a severity of "Info".
+	AWSSNSConditionHandlerRegistered = "HandlerRegistered"
 )
 
 // Reasons for status conditions

--- a/pkg/reconciler/awssnssource/adapter.go
+++ b/pkg/reconciler/awssnssource/adapter.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/system"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
@@ -52,6 +53,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		// required by multi-tenant adapters to enable HA
+		resource.EnvVar(system.NamespaceEnvKey, src.GetNamespace()),
 	)
 }
 

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -74,6 +74,7 @@ func NewAdapterDeployment(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...r
 			resource.ServiceAccount(AdapterRBACObjectsName(src)),
 
 			resource.EnvVar(envSink, sinkURIStr),
+			resource.EnvVar(envComponent, app),
 		}, opts...)...,
 	)
 }
@@ -109,6 +110,7 @@ func NewAdapterKnService(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...re
 			resource.ServiceAccount(AdapterRBACObjectsName(src)),
 
 			resource.EnvVar(envSink, sinkURIStr),
+			resource.EnvVar(envComponent, app),
 			resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
 		}, opts...)...,
 	)

--- a/pkg/reconciler/common/doc.go
+++ b/pkg/reconciler/common/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package common contains reconciliation helpers shared by source reconcilers.
+// Package common contains reconciliation helpers shared between source reconcilers.
 package common


### PR DESCRIPTION
Embed a skeleton of reconciler into the AWSSNSSource adapter that implements both Reconciler (add HTTP route) and Finalizer (remove HTTP route).

At this stage, the adapter still handles a single endpoint at `/`, the actual routing logic is in TODO. I'm marking the PR as ready nevertheless, because I think the code will be easier to review if it is split into two logical PRs. (thoughts?)