### PR TITLE
Fix bug in cloudwatch name setting

### DIFF
--- a/pkg/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/adapter/awscloudwatchsource/adapter.go
@@ -112,21 +112,19 @@ func parseQueries(rawQuery string) ([]*cloudwatch.MetricDataQuery, error) {
 	}
 
 	for _, v := range rawQueries {
-		var q cloudwatch.MetricDataQuery
+		name := v.Name
 
 		if v.Expression != nil {
-			q = cloudwatch.MetricDataQuery{
+			queries = append(queries, &cloudwatch.MetricDataQuery{
 				Expression: v.Expression,
-				Id:         &v.Name,
-			}
+				Id:         &name,
+			})
 		} else if v.Metric != nil {
-			q = cloudwatch.MetricDataQuery{
-				Id:         &v.Name,
+			queries = append(queries, &cloudwatch.MetricDataQuery{
+				Id:         &name,
 				MetricStat: transformQuery(v.Metric),
-			}
+			})
 		}
-
-		queries = append(queries, &q)
 	}
 	return queries, nil
 }


### PR DESCRIPTION
Observed a bug while prepping a demo where the string pointer being used for the metric name is associated with an object that is reused in a for loop, and not the underlying string. This is resulting in the same pointer address being used, and as a result the last name defined within the metric being used for all entries.

Additionally, this PR performs a slight optimization to appending metric queries.