### PR TITLE
Disallow empty name/key in valueFromSecret refs

### DIFF
--- a/config/300-awscloudwatch.yaml
+++ b/config/300-awscloudwatch.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,6 +106,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -122,6 +125,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awscloudwatchlogs.yaml
+++ b/config/300-awscloudwatchlogs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -85,6 +88,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awscodecommit.yaml
+++ b/config/300-awscodecommit.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,6 +75,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -91,6 +94,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awscognitoidentity.yaml
+++ b/config/300-awscognitoidentity.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -83,6 +86,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awscognitouserpool.yaml
+++ b/config/300-awscognitouserpool.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -83,6 +86,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awsdynamodb.yaml
+++ b/config/300-awsdynamodb.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -85,6 +88,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awskinesis.yaml
+++ b/config/300-awskinesis.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -83,6 +86,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awss3.yaml
+++ b/config/300-awss3.yaml
@@ -102,6 +102,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: [value]
                     - required: [valueFromSecret]
@@ -118,6 +121,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: [value]
                     - required: [valueFromSecret]

--- a/config/300-awssns.yaml
+++ b/config/300-awssns.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,6 +86,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -102,6 +105,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']

--- a/config/300-awssqs.yaml
+++ b/config/300-awssqs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']
@@ -83,6 +86,9 @@ spec:
                             type: string
                           key:
                             type: string
+                        required:
+                        - name
+                        - key
                     oneOf:
                     - required: ['value']
                     - required: ['valueFromSecret']


### PR DESCRIPTION
@JeffNeff noticed today that it was currently possible to set a `valueFromSecret` without name or key. This is not expected.

This PR marks those fields as required in OpenAPI schemas.