### PR TITLE
Refactor Spec

### DIFF
--- a/config/300-awsperformanceinsights.yaml
+++ b/config/300-awsperformanceinsights.yaml
@@ -51,7 +51,7 @@ spec:
             properties:
               arn:
                 type: string
-                pattern: arn:aws(-cn|-us-gov)?:rds:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
+                pattern: ^arn:aws(-cn|-us-gov)?:rds:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               pollingInterval:
                 type: string
               metricQueries:

--- a/config/300-awsperformanceinsights.yaml
+++ b/config/300-awsperformanceinsights.yaml
@@ -23,7 +23,7 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "com.amazon.pi.insight" }
+        { "type": "com.amazon.rds.pi.insight" }
       ]
 spec:
   group: sources.triggermesh.io
@@ -51,6 +51,7 @@ spec:
             properties:
               arn:
                 type: string
+                pattern: arn:aws(-cn|-us-gov)?:rds:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               pollingInterval:
                 type: string
               metricQueries:
@@ -58,10 +59,6 @@ spec:
                 items:
                   type: string
                   minLength: 1
-              identifier:
-                type: string
-              serviceType:
-                type: string
               credentials:
                 type: object
                 properties:
@@ -131,8 +128,6 @@ spec:
             - sink
             - pollingInterval
             - metricQueries
-            - identifier
-            - serviceType
           status:
             type: object
             properties:

--- a/config/300-awsperformanceinsights.yaml
+++ b/config/300-awsperformanceinsights.yaml
@@ -23,7 +23,7 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "com.amazon.rds.pi.insight" }
+        { "type": "com.amazon.rds.pi.metric" }
       ]
 spec:
   group: sources.triggermesh.io

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/pi"
+	"github.com/aws/aws-sdk-go/service/rds"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
@@ -35,6 +36,8 @@ import (
 	"github.com/triggermesh/aws-event-sources/pkg/adapter/common"
 	"github.com/triggermesh/aws-event-sources/pkg/apis/sources/v1alpha1"
 )
+
+const serviceType = "RDS"
 
 // envConfig is a set parameters sourced from the environment for the source's
 // adapter.
@@ -46,10 +49,6 @@ type envConfig struct {
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"`
 
 	MetricQueries []string `envconfig:"METRIC_QUERIES" required:"true"`
-
-	Identifier string `envconfig:"IDENTIFIER" required:"true"`
-
-	ServiceType string `envconfig:"SERVICE_TYPE" required:"true" `
 }
 
 // adapter implements the source's adapter.
@@ -62,8 +61,7 @@ type adapter struct {
 	arn             arn.ARN
 	pollingInterval time.Duration
 	metricQueries   []*pi.MetricQuery
-	identifier      string
-	serviceType     string
+	resourceID      string
 }
 
 // event represents the structured event data to be sent as the payload of the Cloudevent
@@ -102,6 +100,22 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		mql = append(mql, m)
 	}
 
+	r := rds.New(cfg)
+
+	var resourceID string
+
+	dbi, err := r.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
+	if err != nil {
+		logger.Panicf("Unable describe DB clusters: %v", zap.Error(err))
+	}
+
+	for _, instance := range dbi.DBInstances {
+		if *instance.DBInstanceArn == a.String() {
+			resourceID = *instance.DbiResourceId
+
+		}
+	}
+
 	return &adapter{
 		logger: logger,
 
@@ -112,8 +126,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 		pollingInterval: interval,
 		metricQueries:   mql,
-		identifier:      env.Identifier,
-		serviceType:     env.ServiceType,
+		resourceID:      resourceID,
 	}
 }
 
@@ -144,9 +157,9 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 	rmi := &pi.GetResourceMetricsInput{
 		EndTime:       aws.Time(time.Now()),
 		StartTime:     aws.Time(priorTime),
-		Identifier:    aws.String(a.identifier),
+		Identifier:    aws.String(a.resourceID),
 		MetricQueries: a.metricQueries,
-		ServiceType:   aws.String(a.serviceType),
+		ServiceType:   aws.String(serviceType),
 	}
 
 	rm, err := a.pIClient.GetResourceMetrics(rmi)
@@ -165,7 +178,7 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 				}
 
 				event := cloudevents.NewEvent(cloudevents.VersionV1)
-				event.SetType(v1alpha1.AWSEventType(a.arn.Service, v1alpha1.AWSPerformanceInsightsGenericEventType))
+				event.SetType(v1alpha1.AWSPerformanceInsightsGenericEventType)
 				event.SetSource(*d.Key.Metric)
 
 				ceer := event.SetData(cloudevents.ApplicationJSON, e)

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -176,7 +176,8 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 
 				event := cloudevents.NewEvent(cloudevents.VersionV1)
 				event.SetType(v1alpha1.AWSPerformanceInsightsGenericEventType)
-				event.SetSource(*d.Key.Metric)
+				event.SetSource(a.arn.String())
+				event.SetExtension("pimetric", d.Key.Metric)
 				ceer := event.SetData(cloudevents.ApplicationJSON, e)
 				if ceer != nil {
 					a.logger.Errorf("failed to set event data: %v", err)

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -104,7 +104,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 	var resourceID string
 	dbi, err := r.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
 	if err != nil {
-		logger.Panicf("Unable describe DB clusters: %v", zap.Error(err))
+		logger.Panicf("Unable describe DB instances: %v", zap.Error(err))
 	}
 
 	for _, instance := range dbi.DBInstances {

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -112,7 +112,6 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 	for _, instance := range dbi.DBInstances {
 		if *instance.DBInstanceArn == a.String() {
 			resourceID = *instance.DbiResourceId
-
 		}
 	}
 
@@ -180,7 +179,6 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 				event := cloudevents.NewEvent(cloudevents.VersionV1)
 				event.SetType(v1alpha1.AWSPerformanceInsightsGenericEventType)
 				event.SetSource(*d.Key.Metric)
-
 				ceer := event.SetData(cloudevents.ApplicationJSON, e)
 				if ceer != nil {
 					a.logger.Errorf("failed to set event data: %v", err)
@@ -196,5 +194,4 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 			}
 		}
 	}
-
 }

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -101,9 +101,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 	}
 
 	r := rds.New(cfg)
-
 	var resourceID string
-
 	dbi, err := r.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
 	if err != nil {
 		logger.Panicf("Unable describe DB clusters: %v", zap.Error(err))

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
@@ -53,7 +53,7 @@ func (s *AWSPerformanceInsightsSource) GetStatusManager() *EventSourceStatusMana
 
 // Supported event types
 const (
-	AWSPerformanceInsightsGenericEventType = "pi.insight"
+	AWSPerformanceInsightsGenericEventType = "com.amazon.rds.pi.insight"
 )
 
 // GetEventTypes implements EventSource.

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
@@ -53,7 +53,7 @@ func (s *AWSPerformanceInsightsSource) GetStatusManager() *EventSourceStatusMana
 
 // Supported event types
 const (
-	AWSPerformanceInsightsGenericEventType = "com.amazon.rds.pi.insight"
+	AWSPerformanceInsightsGenericEventType = "com.amazon.rds.pi.metric"
 )
 
 // GetEventTypes implements EventSource.

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
@@ -55,10 +55,6 @@ type AWSPerformanceInsightsSourceSpec struct {
 	Credentials AWSSecurityCredentials `json:"credentials"`
 
 	MetricQueries []string `json:"metricQueries"`
-
-	Identifier string `json:"identifier"`
-
-	ServiceType string `json:"serviceType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/reconciler/awsperformanceinsightssource/adapter.go
@@ -35,8 +35,6 @@ import (
 const (
 	envPollingInterval = "POLLING_INTERVAL"
 	envMetricQueries   = "METRIC_QUERIES"
-	envIdentifier      = "IDENTIFIER"
-	envServiceType     = "SERVICE_TYPE"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -61,8 +59,6 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVar(envPollingInterval, typedSrc.Spec.PollingInterval.String()),
 		resource.EnvVar(envMetricQueries, strings.Join(typedSrc.Spec.MetricQueries, ",")),
-		resource.EnvVar(envIdentifier, typedSrc.Spec.Identifier),
-		resource.EnvVar(envServiceType, typedSrc.Spec.ServiceType),
 
 		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),


### PR DESCRIPTION
Removed identifier & serviceType from the spec. We are now pulling the ResourceID from the provided ARN. 

I also slid in ARN Validation to the CRD and updated the Event type

An example of the new spec:
```
apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSPerformanceInsightsSource
metadata:
    name: pi
spec:
    arn: arn:aws:rds:us-west-2:925906438773:db:database-2-instance-1
    pollingInterval: 1m
    metricQueries: 
      - os.cpuUtilization.idle.avg
      - os.general.numVCPUs.avg
      - os.network.rx.avg
      - os.network.tx.avg
      - os.network.rx.avg
      - os.fileSys.total.avg 
      - os.fileSys.used.avg 
      - os.memory.active.avg
      - os.memory.total.avg
      - os.tasks.blocked.avg
      - os.tasks.zombie.avg
    credentials:
        accessKeyID:
            valueFromSecret:
                key: access_key_id
                name: aws
        secretAccessKey:
            valueFromSecret:
                key: secret_access_key
                name: aws
    sink:
        ref:
            apiVersion: serving.knative.dev/v1
            kind: Service
            name: event-display
```