### PR TITLE
retry SNS reconciliation if InvalidParameter

### DIFF
--- a/pkg/reconciler/awssnssource/subscription.go
+++ b/pkg/reconciler/awssnssource/subscription.go
@@ -91,7 +91,7 @@ func (r *Reconciler) ensureSubscribed(ctx context.Context) error {
 			//
 			// However "InvalidParameter" is returned if the subscription URL is not ready, which
 			// might be the case if the endpoint for the source is not exposed yet.
-			if awsErr := awserr.Error(nil); errors.As(err, &awsErr) && awsErr.Code() != "InvalidParameter" {
+			if awsErr := awserr.Error(nil); errors.As(err, &awsErr) && awsErr.Code() == sns.ErrCodeInvalidParameterException {
 				return event
 			}
 


### PR DESCRIPTION
`InvalidParameter` code might be [returned from AWS](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html#API_Subscribe_Errors) as the result of an unsuccessful subscribe operation.

The parameter provided from the controller using the external URL for the source, chances that the parameter is invalid (wrong URL) are low. It looks like at subscription time AWS tests the endpoint and if it is not ready yet, the `InvalidParameter` will be returned, making the reconciliation fail.

For such cases, that error code should be treated as non permanent at the SNS source.