### PR TITLE
Document OpenAPI schema for AWSCloudWatchSource

### DIFF
--- a/config/300-awscloudwatch.yaml
+++ b/config/300-awscloudwatch.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,62 +46,93 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Amazon CloudWatch.
         type: object
         properties:
           spec:
+            description: Desired state of the event source.
             type: object
             properties:
               region:
+                description: Code of the AWS region to source metrics from. Available region codes are documented in the
+                  AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
                 type: string
+                pattern: ^[a-z]{2}(-gov)?-[a-z]+-\d$
               pollingInterval:
+                description: Duration which defines how often metrics should be pulled from Amazon CloudWatch. Expressed
+                  as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+                  Defaults to 5m
                 type: string
               metricQueries:
+                description: List of queries that determine what metrics will be sourced from Amazon CloudWatch.
+                  Each item represents an individual MetricDataQuery. For more information, please refer to the
+                  CloudWatch API reference at
+                  https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDataQuery.html
                 type: array
                 items:
                   type: object
                   properties:
                     name:
+                      description: Unique short name that identifies the query.
                       type: string
                       pattern: ^[a-z]\w{0,254}$
                     expression:
+                      description: Math expression to be performed on the metric data. Mutually exclusive with 'metric'.
                       type: string
                     metric:
+                      description: Representation of a metric with statistics, period, and units, but no math
+                        expression. Mutually exclusive with 'expression'.
                       type: object
                       properties:
                         period:
+                          description: The granularity, in seconds, of the returned data points.
                           type: integer
                         stat:
+                          description: The statistic to return.
                           type: string
                         unit:
+                          description: If specified, return only data with that unit.
                           type: string
                         metric:
+                          description: The metric to return.
                           type: object
                           properties:
                             metricName:
+                              description: Name of the metric.
                               type: string
                             namespace:
+                              description: Namespace of the metric.
                               type: string
                             dimensions:
+                              description: Dimensions of the metric.
                               type: array
                               items:
                                 type: object
                                 properties:
                                   name:
+                                    description: Name of the dimension.
                                     type: string
                                   value:
+                                    description: Value of the dimension.
                                     type: string
                   oneOf:
-                  - required: ['expression']
-                  - required: ['metric']
+                  - required: [expression]
+                  - required: [metric]
               credentials:
+                description: Credentials to interact with the Amazon CloudWatch API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   accessKeyID:
+                    description: Access key ID.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the access key ID.
                         type: string
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the access key ID.
                         type: object
                         properties:
                           name:
@@ -112,15 +143,18 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
                   secretAccessKey:
+                    description: Secret access key.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the secret access key.
                         type: string
                         format: password
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the secret access key.
                         type: object
                         properties:
                           name:
@@ -131,12 +165,14 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
               sink:
+                description: The destination of events generated from Amazon CloudWatch metrics.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -152,19 +188,22 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
-                - required: ['ref']
-                - required: ['uri']
+                - required: [ref]
+                - required: [uri]
             required:
             - region
             - metricQueries
             - sink
           status:
+            description: Reported status of the event source.
             type: object
             properties:
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -48,31 +48,39 @@ var (
 type AWSCloudWatchSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// AWS Region for metrics
+	// Code of the AWS region to source metrics from.
+	// Available region codes are documented at
+	// https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
 	Region string `json:"region"`
-	// List of metric queries
-	// +optional
-	MetricQueries []AWSCloudWatchMetricQuery `json:"metricQueries,omitempty"`
-	// PollingInterval in a duration format for how often to pull metrics data from. Default is 5m
+
+	// Duration which defines how often metrics should be pulled from Amazon CloudWatch.
+	// Expressed as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+	//
+	// Defaults to 5m
+	//
 	// +optional
 	PollingInterval *apis.Duration `json:"pollingInterval,omitempty"`
 
-	// Credentials to interact with the AWS CloudWatch API.
+	// List of queries that determine what metrics will be sourced from Amazon CloudWatch.
+	// +optional
+	MetricQueries []AWSCloudWatchMetricQuery `json:"metricQueries,omitempty"`
+
+	// Credentials to interact with the Amazon CloudWatch API.
 	Credentials AWSSecurityCredentials `json:"credentials"`
 }
 
-// Define the metric to return. Consult the AWS CloudWatch API Guide for details:
-// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/Welcome.html
+// AWSCloudWatchMetricQuery represents a CloudWatch MetricDataQuery.
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDataQuery.html
 type AWSCloudWatchMetricQuery struct {
-	// Unique short-name identify the query
+	// Unique short name that identifies the query.
 	Name string `json:"name"`
 
 	// Optional: no more than one of the following may be specified.
 
-	// Math expression for calculating metrics
+	// Math expression to be performed on the metric data.
 	// +optional
 	Expression *string `json:"expression,omitempty"`
-	// Metric for retrieving specific metrics
+	// Representation of a metric with statistics, period, and units, but no math expression.
 	// +optional
 	Metric *AWSCloudWatchMetricStat `json:"metric,omitempty"`
 }


### PR DESCRIPTION
Part of #313

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain awscloudwatchsources.spec
KIND:     AWSCloudWatchSource
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   credentials  <Object>
     Credentials to interact with the AWS CloudWatch API. For more information
     about AWS security credentials, please refer to the AWS General Reference
     at
     https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

   metricQueries        <[]Object> -required-
     List of queries that determine what metrics will be sourced from Amazon
     CloudWatch. Each item represents an individual MetricDataQuery. For more
     information, please refer to the CloudWatch API reference at
     https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDataQuery.html

   pollingInterval      <string>
     Duration which defines how often metrics should be pulled from Amazon
     CloudWatch. Expressed as a duration string, which format is documented at
     https://pkg.go.dev/time#ParseDurationPollingInterval. Defaults to 5m

   region       <string> -required-
     Code of the AWS region to source metrics from. Available region codes are
     documented in the AWS General Reference at
     https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.

   sink <Object> -required-
     The destination of events generated from Amazon CloudWatch metrics.
```