### PR TITLE
Document OpenAPI schema for AWSCloudWatchLogsSource

### DIFF
--- a/config/300-awscloudwatchlogs.yaml
+++ b/config/300-awscloudwatchlogs.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,25 +45,38 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Amazon CloudWatch Logs.
         type: object
         properties:
           spec:
+            description: Desired state of the event source.
             type: object
             properties:
               arn:
+                description: ARN of the Log Group to source data from. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies
                 type: string
-                pattern: '^arn:aws(-cn|-us-gov)?:logs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
+                pattern: ^arn:aws(-cn|-us-gov)?:logs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               pollingInterval:
+                description: Duration which defines how often logs should be pulled from Amazon CloudWatch Logs.
+                  Expressed as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+                  Defaults to 5m
                 type: string
               credentials:
+                description: Credentials to interact with the Amazon CloudWatch Logs API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   accessKeyID:
+                    description: Access key ID.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the access key ID.
                         type: string
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the access key ID.
                         type: object
                         properties:
                           name:
@@ -74,15 +87,18 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
                   secretAccessKey:
+                    description: Secret access key.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the secret access key.
                         type: string
                         format: password
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the secret access key.
                         type: object
                         properties:
                           name:
@@ -93,12 +109,14 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
               sink:
+                description: The destination of events generated from Amazon CloudWatch Logs.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -114,18 +132,21 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
-                - required: ['ref']
-                - required: ['uri']
+                - required: [ref]
+                - required: [uri]
             required:
             - arn
             - sink
           status:
+            description: Reported status of the event source.
             type: object
             properties:
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -48,14 +48,19 @@ var (
 type AWSCloudWatchLogsSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	// ARN for Log Group
+	// ARN of the Log Group to source data from.
 	// https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies
 	ARN apis.ARN `json:"arn"`
-	// PollingInterval in a duration format for how often to pull metrics data from. Default is 5m
+
+	// Duration which defines how often logs should be pulled from Amazon CloudWatch Logs.
+	// Expressed as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+	//
+	// Defaults to 5m
+	//
 	// +optional
 	PollingInterval *apis.Duration `json:"pollingInterval,omitempty"`
 
-	// Credentials to interact with the AWS CloudWatch Logs API.
+	// Credentials to interact with the Amazon CloudWatch Logs API.
 	Credentials AWSSecurityCredentials `json:"credentials"`
 }
 


### PR DESCRIPTION
Part of #313

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain awscloudwatchlogssources.spec
KIND:     AWSCloudWatchLogsSource
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   arn  <string> -required-
     ARN of the Log Group to source data from. The expected format is documented
     at
     https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies

   credentials  <Object>
     Credentials to interact with the Amazon CloudWatch Logs API. For more
     information about AWS security credentials, please refer to the AWS General
     Reference at
     https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

   pollingInterval      <string>
     Duration which defines how often logs should be pulled from Amazon
     CloudWatch Logs. Expressed as a duration string, which format is documented
     at https://pkg.go.dev/time#ParseDurationPollingInterval. Defaults to 5m

   sink <Object> -required-
     The destination of events generated from Amazon CloudWatch Logs.
````