### PR TITLE
Document OpenAPI schema for AWSS3Source

### DIFF
--- a/config/300-awss3.yaml
+++ b/config/300-awss3.yaml
@@ -50,23 +50,29 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Amazon S3.
         type: object
         properties:
           spec:
+            description: Desired state of the event source.
             type: object
             properties:
               arn:
+                description: ARN of the S3 bucket to receive notifications from. The expected format is
+                  'arn:${Partition}:s3:${Region}:${Account}:${BucketName}'. Although not technically required by S3, we
+                  enforce that bucket ARNs include a region and an account ID, because this information is required by
+                  the source to operate properly. See also
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-resources-for-iam-policies.
                 type: string
                 # Bucket naming rules
                 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
                 pattern: ^arn:aws(-cn|-us-gov)?:s3:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:[0-9a-z][0-9a-z.-]{2,62}$
               eventTypes:
+                description: List of event types that the source should subscribe to. Accepted values are listed at
+                  https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html.
                 type: array
                 items:
                   type: string
-                  # Accepted values
-                  # https://docs.aws.amazon.com/AmazonS3/latest/API/API_QueueConfiguration.html
-                  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
                   enum:
                   - s3:ObjectCreated:*
                   - s3:ObjectCreated:Put
@@ -86,17 +92,27 @@ spec:
                   - s3:Replication:OperationMissedThreshold
                   - s3:Replication:OperationReplicatedAfterThreshold
               queueARN:
+                description: ARN of the Amazon SQS queue that should be receiving notifications from the Amazon S3
+                  bucket. When not provided, a SQS queue is automatically created and associated with the bucket. The
+                  expected format is documented at
+                  https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               credentials:
+                description: Credentials to interact with the Amazon S3 and SQS APIs. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   accessKeyID:
+                    description: Access key ID.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the access key ID.
                         type: string
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the access key ID.
                         type: object
                         properties:
                           name:
@@ -110,12 +126,15 @@ spec:
                     - required: [value]
                     - required: [valueFromSecret]
                   secretAccessKey:
+                    description: Secret access key.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the secret access key.
                         type: string
                         format: password
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the secret access key.
                         type: object
                         properties:
                           name:
@@ -129,9 +148,11 @@ spec:
                     - required: [value]
                     - required: [valueFromSecret]
               sink:
+                description: The destination of events sourced from Amazon S3.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -147,6 +168,7 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
@@ -157,11 +179,15 @@ spec:
             - eventTypes
             - sink
           status:
+            description: Reported status of the event source.
             type: object
             properties:
               queueARN:
+                description: ARN of the Amazon SQS queue that is currently receiving notifications from the Amazon S3
+                  bucket.
                 type: string
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -71,7 +71,7 @@ type AWSS3SourceSpec struct {
 	// +optional
 	QueueARN *apis.ARN `json:"queueARN,omitempty"`
 
-	// Credentials to interact with the AWS S3 and SQS APIs.
+	// Credentials to interact with the Amazon S3 and SQS APIs.
 	Credentials AWSSecurityCredentials `json:"credentials"`
 }
 


### PR DESCRIPTION
Part of #313

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain awss3sources.spec
KIND:     AWSS3Source
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   arn  <string> -required-
     ARN of the S3 bucket to receive notifications from. The expected format is
     'arn:${Partition}:s3:${Region}:${Account}:${BucketName}'. Although not
     technically required by S3, we enforce that bucket ARNs include a region
     and an account ID, because this information is required by the source to
     operate properly. See also
     https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-resources-for-iam-policies.

   credentials  <Object>
     Credentials to interact with the Amazon S3 and SQS APIs. For more
     information about AWS security credentials, please refer to the AWS General
     Reference at
     https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

   eventTypes   <[]string> -required-
     List of event types that the source should subscribe to. Accepted values
     are listed at
     https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html.

   queueARN     <string>
     ARN of the Amazon SQS queue that should be receiving notifications from the
     Amazon S3 bucket. When not provided, a SQS queue is automatically created
     and associated with the bucket. The expected format is documented at
     https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.

   sink <Object> -required-
     The destination of events sourced from Amazon S3.
```