### PR TITLE
Document OpenAPI schema for AWSSQSSource

### DIFF
--- a/config/300-awssqs.yaml
+++ b/config/300-awssqs.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,23 +45,33 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Amazon SQS.
         type: object
         properties:
           spec:
+            description: Desired state of the event source.
             type: object
             properties:
               arn:
+                description: ARN of the Amazon SQS queue to consume messages from. The expected format is documented at
+                  https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.
                 type: string
-                pattern: '^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
+                pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               credentials:
+                description: Credentials to interact with the Amazon SQS API. For more information about AWS security
+                  credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   accessKeyID:
+                    description: Access key ID.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the access key ID.
                         type: string
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the access key ID.
                         type: object
                         properties:
                           name:
@@ -72,15 +82,18 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
                   secretAccessKey:
+                    description: Secret access key.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the secret access key.
                         type: string
                         format: password
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the secret access key.
                         type: object
                         properties:
                           name:
@@ -91,12 +104,14 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
               sink:
+                description: The destination of events sourced from Amazon SQS.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -112,18 +127,21 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
-                - required: ['ref']
-                - required: ['uri']
+                - required: [ref]
+                - required: [uri]
             required:
             - arn
             - sink
           status:
+            description: Reported status of the event source.
             type: object
             properties:
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,7 +52,7 @@ type AWSSQSSourceSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies
 	ARN apis.ARN `json:"arn"`
 
-	// Credentials to interact with the AWS SQS API.
+	// Credentials to interact with the Amazon SQS API.
 	Credentials AWSSecurityCredentials `json:"credentials"`
 }
 


### PR DESCRIPTION
Part of #313

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain awssqssources.spec
KIND:     AWSSQSSource
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   arn  <string> -required-
     ARN of the Amazon SQS queue to consume messages from. The expected format
     is documented at
     https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.

   credentials  <Object>
     Credentials to interact with the Amazon SQS API. For more information about
     AWS security credentials, please refer to the AWS General Reference at
     https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

   sink <Object> -required-
     The destination of events sourced from Amazon SQS.
```