### PR TITLE
Document OpenAPI schema for AWSSNSSource

### DIFF
--- a/config/300-awssns.yaml
+++ b/config/300-awssns.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,42 +45,58 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Amazon SNS.
         type: object
         properties:
           spec:
+            description: Desired state of the event source.
             type: object
             properties:
               arn:
+                description: ARN of the Amazon SNS topic to consume messages from. The expected format is documented at
+                  https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies
                 type: string
-                pattern: '^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$'
+                pattern: ^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               subscriptionAttributes:
+                description: Attributes to set on the Amazon SNS Subscription that is used for receiving messages from
+                  the SNS topic.
                 type: object
                 properties:
                   DeliveryPolicy:
+                    description: Policy that defines how Amazon SNS retries failed deliveries to this event source.
                     type: string
                     format: json
                     nullable: true
                   FilterPolicy:
+                    description: Rules for filtering the messages sent to this event source.
                     type: string
                     format: json
                     nullable: true
                   RawMessageDelivery:
+                    description: Whether to enable raw message delivery to this event source.
                     type: string
                     format: json
                     nullable: true
                   RedrivePolicy:
+                    description: Send undeliverable messages to the specified Amazon SQS dead-letter queue.
                     type: string
                     format: json
                     nullable: true
               credentials:
+                description: Credentials to interact with the Amazon SNS API. For more information about AWS security
+                  credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   accessKeyID:
+                    description: Access key ID.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the access key ID.
                         type: string
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the access key ID.
                         type: object
                         properties:
                           name:
@@ -91,15 +107,18 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
                   secretAccessKey:
+                    description: Secret access key.
                     type: object
                     properties:
                       value:
+                        description: Literal value of the secret access key.
                         type: string
                         format: password
                       valueFromSecret:
+                        description: A reference to a Kubernetes Secret object containing the secret access key.
                         type: object
                         properties:
                           name:
@@ -110,12 +129,14 @@ spec:
                         - name
                         - key
                     oneOf:
-                    - required: ['value']
-                    - required: ['valueFromSecret']
+                    - required: [value]
+                    - required: [valueFromSecret]
               sink:
+                description: The destination of events sourced from Amazon SNS.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -131,20 +152,25 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
-                - required: ['ref']
-                - required: ['uri']
+                - required: [ref]
+                - required: [uri]
             required:
             - arn
             - sink
           status:
+            description: Reported status of the event source.
             type: object
             properties:
               subscriptionARN:
+                description: ARN of the Amazon SNS subscription that is currently used for receiving messages from the
+                  SNS topic.
                 type: string
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:
@@ -186,6 +212,7 @@ spec:
                   - type
                   - status
               address:
+                description: Public address of the HTTP/S endpoint that is subscribed to the Amazon SNS topic.
                 type: object
                 properties:
                   url:

--- a/pkg/apis/sources/v1alpha1/awssns_types.go
+++ b/pkg/apis/sources/v1alpha1/awssns_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -55,14 +55,14 @@ type AWSSNSSourceSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies
 	ARN apis.ARN `json:"arn"`
 
-	// Attributes to set on the Subscription.
+	// Attributes to set on the Subscription that is used for receiving messages from the topic.
 	// For a list of supported subscription attributes, please refer to the following resources:
 	//  * https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html
 	//  * https://docs.aws.amazon.com/sns/latest/dg/sns-how-it-works.html
 	// +optional
 	SubscriptionAttributes map[string]*string `json:"subscriptionAttributes,omitempty"`
 
-	// Credentials to interact with the AWS SNS API.
+	// Credentials to interact with the Amazon SNS API.
 	Credentials AWSSecurityCredentials `json:"credentials"`
 }
 


### PR DESCRIPTION
Part of #313

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain awssnssources.spec
KIND:     AWSSNSSource
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   arn  <string> -required-
     ARN of the Amazon SNS topic to consume messages from. The expected format
     is documented at
     https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies

   credentials  <Object>
     Credentials to interact with the Amazon SNS API. For more information about
     AWS security credentials, please refer to the AWS General Reference at
     https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

   sink <Object> -required-
     The destination of events sourced from Amazon SNS.

   subscriptionAttributes       <Object>
     Attributes to set on the Amazon SNS Subscription that is used for receiving
     messages from the SNS topic.
```