### PR TITLE
Hint about using "kubectl explain" inside samples

### DIFF
--- a/config/samples/awscloudwatchlogssource.yaml
+++ b/config/samples/awscloudwatchlogssource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSCloudWatchLogsSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awscloudwatchlogssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSCloudWatchLogsSource

--- a/config/samples/awscloudwatchsource.yaml
+++ b/config/samples/awscloudwatchsource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSCloudWatchSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awscloudwatchsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSCloudWatchSource

--- a/config/samples/awscodecommitsource.yaml
+++ b/config/samples/awscodecommitsource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSCodeCommitSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awscodecommitsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSCodeCommitSource

--- a/config/samples/awscognitoidentitysource.yaml
+++ b/config/samples/awscognitoidentitysource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSCognitoIdentitySource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awscognitoidentitysources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSCognitoIdentitySource

--- a/config/samples/awscognitouserpoolsource.yaml
+++ b/config/samples/awscognitouserpoolsource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSCognitoUserPoolSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awscognitouserpoolsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSCognitoUserPoolSource

--- a/config/samples/awsdynamodbsource.yaml
+++ b/config/samples/awsdynamodbsource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSDynamoDBSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awsdynamodbsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSDynamoDBSource

--- a/config/samples/awskinesissource.yaml
+++ b/config/samples/awskinesissource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSKinesisSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awskinesissources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSKinesisSource

--- a/config/samples/awss3source.yaml
+++ b/config/samples/awss3source.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSS3Source object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awss3sources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSS3Source
@@ -24,8 +29,6 @@ spec:
   eventTypes:
   - s3:ObjectCreated:*
   - s3:ObjectRemoved:*
-
-  queueARN: arn:aws:sqs:us-west-2:123456789012:triggermeshtest # optional
 
   credentials:
     accessKeyID:

--- a/config/samples/awssnssource.yaml
+++ b/config/samples/awssnssource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSSNSSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awssnssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSSNSSource

--- a/config/samples/awssqssource.yaml
+++ b/config/samples/awssqssource.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AWSSQSSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain awssqssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AWSSQSSource


### PR DESCRIPTION
Follow up to #313.

Document the commands users need to execute in order to display the documentation about each custom resource.