### PR TITLE
pi: Rename metricQueries to metrics

### DIFF
--- a/config/300-awsperformanceinsights.yaml
+++ b/config/300-awsperformanceinsights.yaml
@@ -61,10 +61,10 @@ spec:
                 description: Duration which defines how often metrics should be pulled from Amazon Performance Insights.
                   Expressed as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
                 type: string
-              metricQueries:
-                description: List of queries that determine what metrics will be sourced from Amazon Performance
-                  Insights. Each item represents the 'metric' attribute of a MetricQuery. For more information, please
-                  refer to the Performance Insights API reference at
+              metrics:
+                description: List of metrics to retrieve from Amazon Performance Insights. Each item represents the
+                  'metric' attribute of a MetricQuery. For more information, please refer to the Performance Insights API
+                  reference at
                   https://docs.aws.amazon.com/performance-insights/latest/APIReference/API_MetricQuery.html
                 type: array
                 items:
@@ -149,7 +149,7 @@ spec:
             required:
             - arn
             - pollingInterval
-            - metricQueries
+            - metrics
             - sink
           status:
             description: Reported status of the event source.

--- a/pkg/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/adapter/awsperformanceinsightssource/adapter.go
@@ -48,7 +48,7 @@ type envConfig struct {
 
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"`
 
-	MetricQueries []string `envconfig:"METRIC_QUERIES" required:"true"`
+	Metrics []string `envconfig:"PI_METRICS" required:"true"`
 }
 
 // adapter implements the source's adapter.
@@ -95,9 +95,9 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	var mql []*pi.MetricQuery
 
-	for _, r := range env.MetricQueries {
-		m := &pi.MetricQuery{Metric: aws.String(r)}
-		mql = append(mql, m)
+	for _, m := range env.Metrics {
+		mq := &pi.MetricQuery{Metric: aws.String(m)}
+		mql = append(mql, mq)
 	}
 
 	r := rds.New(cfg)

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
@@ -60,7 +60,7 @@ type AWSPerformanceInsightsSourceSpec struct {
 	//
 	// Each item represents the 'metric' attribute of a MetricQuery.
 	// https://docs.aws.amazon.com/performance-insights/latest/APIReference/API_MetricQuery.html
-	MetricQueries []string `json:"metricQueries"`
+	Metrics []string `json:"metrics"`
 
 	// Credentials to interact with the Amazon RDS and Performance Insights APIs.
 	Credentials AWSSecurityCredentials `json:"credentials"`

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -754,8 +754,8 @@ func (in *AWSPerformanceInsightsSourceSpec) DeepCopyInto(out *AWSPerformanceInsi
 	*out = *in
 	in.SourceSpec.DeepCopyInto(&out.SourceSpec)
 	out.ARN = in.ARN
-	if in.MetricQueries != nil {
-		in, out := &in.MetricQueries, &out.MetricQueries
+	if in.Metrics != nil {
+		in, out := &in.Metrics, &out.Metrics
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/reconciler/awsperformanceinsightssource/adapter.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	envPollingInterval = "POLLING_INTERVAL"
-	envMetricQueries   = "METRIC_QUERIES"
+	envMetrics         = "PI_METRICS"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -58,7 +58,7 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVar(envPollingInterval, typedSrc.Spec.PollingInterval.String()),
-		resource.EnvVar(envMetricQueries, strings.Join(typedSrc.Spec.MetricQueries, ",")),
+		resource.EnvVar(envMetrics, strings.Join(typedSrc.Spec.Metrics, ",")),
 
 		resource.EnvVars(common.MakeSecurityCredentialsEnvVars(typedSrc.Spec.Credentials)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),


### PR DESCRIPTION
Closes #284

tl;dr: _What we call a "metrics_query" is not the same things as the "metric_query" defined by Amazon._

As discussed in the referenced issue, this source only allows users to request a list of **metrics**, without the `GroupBy` and `Filter` attributes available inside Amazon's actual [`MetricQueries`](https://docs.aws.amazon.com/performance-insights/latest/APIReference/API_MetricQuery.html).

In a effort to keep the vocabulary of our APIs as accurate as possible, I suggest we rename

```yaml
metric_queries: []
```

to

```yaml
metrics: []
```