### PR TITLE
sqs: Include all message attributes in event data

### DIFF
--- a/pkg/adapter/awssqssource/receive.go
+++ b/pkg/adapter/awssqssource/receive.go
@@ -98,12 +98,15 @@ func (ml messageList) MarshalLogArray(arr zapcore.ArrayEncoder) error {
 func receiveMessages(ctx context.Context, cli sqsiface.SQSAPI,
 	queueURL string, visibilityTimeoutSeconds *int64) ([]*sqs.Message, error) {
 
+	allAttributes := aws.StringSlice([]string{sqs.QueueAttributeNameAll})
+
 	resp, err := cli.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
-		AttributeNames:      aws.StringSlice([]string{sqs.QueueAttributeNameAll}),
-		QueueUrl:            &queueURL,
-		MaxNumberOfMessages: aws.Int64(maxReceiveMsgBatchSize),
-		WaitTimeSeconds:     aws.Int64(maxLongPollingWaitTimeSeconds),
-		VisibilityTimeout:   visibilityTimeoutSeconds,
+		AttributeNames:        allAttributes,
+		MessageAttributeNames: allAttributes,
+		QueueUrl:              &queueURL,
+		MaxNumberOfMessages:   aws.Int64(maxReceiveMsgBatchSize),
+		WaitTimeSeconds:       aws.Int64(maxLongPollingWaitTimeSeconds),
+		VisibilityTimeout:     visibilityTimeoutSeconds,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
SQS message attributes were not fetched at all until now, therefore we never included them into our events' data.
This PR ensures all message attributes are included.

In a future improvement, we may offer users the option to select what attributes they are interested in, instead of defaulting to "All".

Fixes #330