### PR TITLE
sqs: Propagate message attrs to CloudEvents context

### DIFF
--- a/pkg/adapter/awssqssource/cloudevents.go
+++ b/pkg/adapter/awssqssource/cloudevents.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqssource
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+)
+
+const sqsMgsAttrDataTypeBinary = "Binary"
+const ceExtensionSQSMessagePrefix = "sqsmsg"
+
+// ceExtensionAttrsForMessage returns a collection of CloudEvents extension
+// attributes translated from the message attributes of the given SQS message.
+//
+// Attributes with a Binary data type are excluded.
+// The resulting extension attribute name is composed of the 'sqsmsg' prefix,
+// followed by the lowercase name of the SQS message attribute, from which all
+// non-alphanumeric characters have been removed (e.g. "sqsmsgmyattribute").
+//
+// https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#extension-context-attributes
+func ceExtensionAttrsForMessage(msg *sqs.Message) map[string]interface{} {
+	if len(msg.MessageAttributes) == 0 {
+		return nil
+	}
+
+	ceExtAttrs := make(map[string]interface{})
+
+	for name, attrVal := range msg.MessageAttributes {
+		if !strings.HasPrefix(*attrVal.DataType, sqsMgsAttrDataTypeBinary) {
+			ceExtAttrs[ceExtensionAttrsForMessageAttr(name)] = *attrVal.StringValue
+		}
+	}
+
+	return ceExtAttrs
+}
+
+// ceExtensionAttrsForMessageAttr sanitizes the name of a SQS message attribute
+// so that it can be used as a CloudEvent context attribute.
+//
+// The naming conventions for both formats are described at:
+//  - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#message-attribute-components
+//  - https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#context-attributes
+func ceExtensionAttrsForMessageAttr(attrName string) string {
+	return ceExtensionSQSMessagePrefix + stripNonAlphanumCharsAndMapToLower(attrName)
+}
+
+// stripNonAlphanumCharsAndMapToLower applies the following transformations to
+// the given string:
+//  - strips all non alphanumeric characters
+//  - maps all Unicode letters to their lower case
+func stripNonAlphanumCharsAndMapToLower(s string) string {
+	var stripped strings.Builder
+	stripped.Grow(len(s))
+
+	// operate on bytes instead of runes, since all alphanumeric characters
+	// are represented in a single byte
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') {
+
+			if 'A' <= b && b <= 'Z' {
+				// shift from upper to lower case
+				b += 'a' - 'A'
+			}
+
+			stripped.WriteByte(b)
+		}
+	}
+
+	return stripped.String()
+}

--- a/pkg/adapter/awssqssource/process.go
+++ b/pkg/adapter/awssqssource/process.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -104,6 +104,11 @@ func makeSQSEvent(msg *sqs.Message, srcAttr string) (*cloudevents.Event, error) 
 	event.SetType(v1alpha1.AWSEventType(sqs.ServiceName, v1alpha1.AWSSQSGenericEventType))
 	event.SetSource(srcAttr)
 	event.SetID(*msg.MessageId)
+
+	for name, val := range ceExtensionAttrsForMessage(msg) {
+		event.SetExtension(name, val)
+	}
+
 	if err := event.SetData(cloudevents.ApplicationJSON, msg); err != nil {
 		return nil, fmt.Errorf("setting CloudEvent data: %w", err)
 	}


### PR DESCRIPTION
Closes #335

Based on my example at https://github.com/triggermesh/aws-event-sources/issues/330#issuecomment-924062007:

![image](https://user-images.githubusercontent.com/3299086/134259078-f60c3252-2f19-4488-9289-014cb87a671e.png)

Notice how the CloudEvents extensions are based on the attributes of the SQS message:

```jsonc
☁️  cloudevents.Event
Context Attributes,
  specversion: 1.0
  type: com.amazon.sqs.message
  source: arn:aws:sqs:us-west-1:123456789012:test
  id: 4c7e252c-88dd-4ae0-9bdc-9a95a70256ff
  time: 2021-09-21T23:08:10.5150431Z
  datacontenttype: application/json
Extensions,
  sqsmsganattribute: The value of An-Attribute
  sqsmsgotherattribute: 3.333333333
Data,
  {
    "Attributes": {
      "ApproximateFirstReceiveTimestamp": "1632265687391",
      "ApproximateReceiveCount": "1",
      "SenderId": "AIDAQUHRFMYWSR2PNVTVZ",
      "SentTimestamp": "1632265687380"
    },
    "Body": "{\"msg\": \"Hello, World!\"}",
    "MD5OfBody": "fa00cf89134387aaa0cd442076e26673",
    "MD5OfMessageAttributes": "23f4a611a378aa04a1bb82d276accb76",
    "MessageAttributes": {
      "An-Attribute": {
        "BinaryListValues": null,
        "BinaryValue": null,
        "DataType": "String.Foo",
        "StringListValues": null,
        "StringValue": "The value of An-Attribute"
      },
      "Other_Attribute": {
        "BinaryListValues": null,
        "BinaryValue": null,
        "DataType": "Number.Bar",
        "StringListValues": null,
        "StringValue": "3.333333333"
      }
    },
    "MessageId": "4c7e252c-88dd-4ae0-9bdc-9a95a70256ff",
    "ReceiptHandle": "AQEBCjJegqUDdZRi3FayTIo6GrnxY9CUGPuZXVF4zyyC+akUyKTwf0JC+b+qEWzQCMhDk0GmRmu+x0Gn7n9aiJRfSYFCTBk6qJM8ecT7kBnYGmaxQja56P4bUxPKvcI++01MhLQaHHwYFzevzbIYwHrLGmLScFw7IIuS3LD8qUEWxBphAIJi6zboWcU81ylCWvp7i+7ESzDUZQothuV5xebC5xXCSGAsGvkr75JzilUWJnQ9hH/bCGURol0Z4W88OSRTfyuImx1YGYjdMIsl0tunXdkyjQorRJ4EKWSSnKC3A4okLbh/hVvh+/FsX+ZiWNaRL7vjP+l7IrxnUNy2fzdqa1d3uC2N9ztfGRONUgOIJQvkJMc4MmRISueHumlJ/Iyj"
  }
```